### PR TITLE
[NR-343531] Workflows for lambda code and templates deployment

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -1,112 +1,19 @@
-name: Pull Request Workflow
+name: Build and Deploy Lambda
 
 on:
-  pull_request:
+  push:
     branches:
       - main
 
+env:
+  log_forwarder_zip_file_name: new-relic-log-forwarder.zip
+
 jobs:
-  validate-template-code:
+  build:
     runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install AWS SAM CLI
-        run: |
-          pip install aws-sam-cli
-
-      - name: Install golint
-        run: |
-          go install golang.org/x/lint/golint@latest
-          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-
-      - name: Lint Go Code
-        run: |
-            # Find all .go files, excluding the vendor directory
-            go_files=$(find . -name "*.go" -not -path "./vendor/*" -not -path "./src/vendor/*")
-            
-            # Run golint on each Go file
-            lint_output=""
-            for file in $go_files; do
-              output=$(golint $file)
-              if [ -n "$output" ]; then
-                lint_output="$lint_output\n$output"
-              fi
-            done
-  
-            if [ -n "$lint_output" ]; then
-              echo "Linting issues found:"
-              echo -e "$lint_output"
-              exit 1
-            else
-              echo "No linting issues found."
-            fi
-      - name: Run gofmt
-        run: |
-          # Find all .go files and check if they are properly formatted
-          unformatted=$(gofmt -l $(find . -name "*.go" -not -path "./src/vendor/*"))
-          if [ -n "$unformatted" ]; then
-            echo "The following files are not formatted:"
-            echo "$unformatted"
-            exit 1
-          else
-            echo "All files are properly formatted."
-          fi
-      
-      - name: Validate SAM Templates
-        run: |
-          for template in $(find . -name ".yaml" -o -name ".yml"); do
-          echo "Validating template: $template"
-          sam validate --template-file "$template" --region us-east-2 --lint
-          done
-  security:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Run CFN Nag Security Checks
-        uses: stelligent/cfn_nag@master
-        with:
-          input_path: .
-          extra_args: -o sarif
-          output_path: cfn_nag.sarif
-      - name: Upload CFN Nag SARIF
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: cfn_nag.sarif    
-          category: security
-                                 
-  trivy-scan:
-    name: Trivy security scan
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Run Trivy vulnerability scanner in repo mode for Low Priority
-        uses: aquasecurity/trivy-action@master
-        with:
-          scan-type: fs
-          ignore-unfixed: true
-          severity: 'LOW,MEDIUM'
-        env:
-          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
-          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db
-      - name: Run Trivy vulnerability scanner in repo mode for High Priority
-        uses: aquasecurity/trivy-action@master
-        with:
-          scan-type: fs
-          ignore-unfixed: true
-          exit-code: 1
-          severity: 'HIGH,CRITICAL'
-        env:
-          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
-          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db
-
-  test-and-coverage:
-    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -115,16 +22,104 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.22'
-      #scripts to include the integration and end to end tests should be added here
-      - name: Run Test Cases and Coverage
+
+      - name: Build and Package Go executable
         run: |
           cd src
-          mkdir -p coverage
-          go test -race -coverprofile=coverage/coverage.out ./...
-          go tool cover -html=coverage/coverage.out -o coverage/coverage.html
+          go mod tidy
+          GOOS=linux GOARCH=amd64 go build -o bootstrap main.go
+          zip -r ../$log_forwarder_zip_file_name .
+          cd ..
 
-      - name: Upload Coverage Report
+      - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
-          name: coverage-report
-          path: src/coverage/coverage.html
+          name: log-forwarder-zip
+          path: log_forwarder_zip_file_name
+
+  deploy-lambda-code:
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        region:
+          - us-east-1
+          - us-east-2
+    #          - eu-west-1
+    #          - eu-west-2
+    #          - us-west-1
+    #          - us-west-2
+    #          - af-south-1
+    #          - ap-east-1
+    #          - ap-south-2
+    #          - ap-southeast-3
+    #          - ap-southeast-5
+    #          - ap-southeast-4
+    #          - ap-south-1
+    #          - ap-northeast-3
+    #          - ap-northeast-2
+    #          - ap-southeast-1
+    #          - ap-southeast-2
+    #          - ap-northeast-1
+    #          - ca-central-1
+    #          - ca-west-1
+    #          - eu-central-1
+    #          - eu-south-1
+    #          - eu-west-3
+    #          - eu-south-2
+    #          - eu-north-1
+    #          - eu-central-2
+    #          - me-south-1
+    #          - me-central-1
+    #          - il-central-1
+    #          - sa-east-1
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          role-to-assume: ${{ secrets.AWS_SAR_PUBLISHER_ROLE }}
+          aws-region: us-east-1
+
+      - name: Upload lambda code to S3 buckets in all AWS region
+        env:
+          bucket_prefix: new-relic-log-forwarder-folder
+          region: ${{ matrix.region }}
+        run: |
+          bucket_name="unified-logging-lambda-code-test-${region}"
+          aws s3 cp "$log_forwarder_zip_file_name" "s3://$bucket_name/$bucket_prefix/" --region "$region"
+          echo "Deploying $log_forwarder_zip_file_name to region $REGION"
+
+  deploy-temaplate-files:
+    needs: deploy-lambda-code
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install AWS SAM CLI
+        run: |
+          pip install aws-sam-cli
+
+      - name: Build and Package SAM Application and Upload to S3
+        env:
+          bucket_name: anusha-test-ansuha
+          region: us-east-1
+        run: |
+          BUILD_DIR_BASE=".aws-sam/build"
+          TEMPLATES=(
+            "logging-lambda-metric-polling.yaml"
+            "logging-lambda-metric-stream.yaml"
+            "logging-firehose-metric-polling.yaml"
+            "logging-firehose-metric-stream.yaml"
+            "logging-lambda-firehose-metric-polling.yaml"
+            "logging-lambda-firehose-metric-stream.yaml"
+            "lambda-template.yaml"
+            "logging-lambda-firehose-template.yaml"
+          )
+          
+          for TEMPLATE_FILE in "${TEMPLATES[@]}"; do
+            BASE_NAME=$(basename "$TEMPLATE_FILE" .yaml)
+            BUILD_DIR="$BUILD_DIR_BASE/$BASE_NAME"
+          
+            sam build --template-file "$TEMPLATE_FILE" --build-dir "$BUILD_DIR"
+            sam package --s3-bucket "$bucket_name" --template-file "$BUILD_DIR/template.yaml" --output-template-file "$BUILD_DIR/$TEMPLATE_FILE" --region $region
+          
+            aws s3 cp "$BUILD_DIR/$TEMPLATE_FILE" "s3://$bucket_name/$TEMPLATE_FILE"
+          done

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -1,7 +1,7 @@
 name: Build and Deploy Lambda
 
 on:
-  pull_request:
+  push:
     branches:
       - main
 
@@ -11,9 +11,6 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -28,17 +25,20 @@ jobs:
           cd src
           go mod tidy
           GOOS=linux GOARCH=amd64 go build -o bootstrap main.go
-          zip -r ../$log_forwarder_zip_file_name .
+          zip -r ../build/$log_forwarder_zip_file_name .
           cd ..
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
           name: log-forwarder-zip
-          path: log_forwarder_zip_file_name
+          path: build
 
   deploy-lambda-code:
     needs: build
+    permissions:
+      id-token: write
+      contents: write
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -77,8 +77,8 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v3
         with:
-          role-to-assume: ${{ secrets.AWS_SAR_PUBLISHER_ROLE }}
-          aws-region: us-east-1
+          role-to-assume: ${{ secrets.AWS_S3_PUBLISH_ROLE_TEMP }}
+          aws-region: us-east-2
 
       - name: Upload lambda code to S3 buckets in all AWS region
         env:
@@ -102,7 +102,6 @@ jobs:
           bucket_name: anusha-test-ansuha
           region: us-east-1
         run: |
-          BUILD_DIR_BASE=".aws-sam/build"
           TEMPLATES=(
             "logging-lambda-metric-polling.yaml"
             "logging-lambda-metric-stream.yaml"
@@ -115,11 +114,7 @@ jobs:
           )
           
           for TEMPLATE_FILE in "${TEMPLATES[@]}"; do
-            BASE_NAME=$(basename "$TEMPLATE_FILE" .yaml)
-            BUILD_DIR="$BUILD_DIR_BASE/$BASE_NAME"
-          
-            sam build --template-file "$TEMPLATE_FILE" --build-dir "$BUILD_DIR"
-            sam package --s3-bucket "$bucket_name" --template-file "$BUILD_DIR/template.yaml" --output-template-file "$BUILD_DIR/$TEMPLATE_FILE" --region $region
-          
-            aws s3 cp "$BUILD_DIR/$TEMPLATE_FILE" "s3://$bucket_name/$TEMPLATE_FILE"
+            sam build --template-file "$TEMPLATE_FILE"
+            sam package --s3-bucket "$bucket_name" --template-file "template.yaml" --output-template-file "$TEMPLATE_FILE" --region $region
+            aws s3 cp "$TEMPLATE_FILE" "s3://$bucket_name/$TEMPLATE_FILE"
           done

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -73,7 +73,14 @@ jobs:
     #          - me-central-1
     #          - il-central-1
     #          - sa-east-1
+
     steps:
+      - name: Download Artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: log-forwarder-zip
+          path: ./build-artifacts
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v3
         with:
@@ -86,7 +93,7 @@ jobs:
           region: ${{ matrix.region }}
         run: |
           bucket_name="unified-logging-lambda-code-test-${region}"
-          aws s3 cp "$log_forwarder_zip_file_name" "s3://$bucket_name/$bucket_prefix/" --region "$region"
+          aws s3 cp "./build-artifacts/$log_forwarder_zip_file_name" "s3://$bucket_name/$bucket_prefix/" --region "$region"
           echo "Deploying $log_forwarder_zip_file_name to region $REGION"
 
   deploy-temaplate-files:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -73,9 +73,11 @@ jobs:
             sam package --s3-bucket "$bucket_name" --template-file "$BUILD_DIR/template.yaml" --output-template-file "$BUILD_DIR/$TEMPLATE_FILE"  --region $region
           
             aws s3 cp "$BUILD_DIR/$TEMPLATE_FILE" "s3://$bucket_name/$TEMPLATE_FILE"
-          done  
+          done
+            
 
   deploy-lambda-code-parallelly-to-all-region:
+    needs: build-and-deploy
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -122,6 +122,6 @@ jobs:
           
           for TEMPLATE_FILE in "${TEMPLATES[@]}"; do
             sam build --template-file "$TEMPLATE_FILE"
-            sam package --s3-bucket "$bucket_name" --template-file "template.yaml" --output-template-file "$TEMPLATE_FILE" --region $region
+            sam package --s3-bucket "$bucket_name" --template-file ".aws-sam/build/template.yaml" --output-template-file "$TEMPLATE_FILE" --region $region
             aws s3 cp "$TEMPLATE_FILE" "s3://$bucket_name/$TEMPLATE_FILE"
           done

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -1,19 +1,112 @@
-name: Build and Deploy Lambda
+name: Pull Request Workflow
 
 on:
-  pull_request:
+  push:
     branches:
       - main
 
-env:
-  log_forwarder_zip_file_name: new-relic-log-forwarder.zip
-
 jobs:
-  build-and-deploy:
+  validate-template-code:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install AWS SAM CLI
+        run: |
+          pip install aws-sam-cli
+
+      - name: Install golint
+        run: |
+          go install golang.org/x/lint/golint@latest
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+
+      - name: Lint Go Code
+        run: |
+          # Find all .go files, excluding the vendor directory
+          go_files=$(find . -name "*.go" -not -path "./vendor/*" -not -path "./src/vendor/*")
+          
+          # Run golint on each Go file
+          lint_output=""
+          for file in $go_files; do
+            output=$(golint $file)
+            if [ -n "$output" ]; then
+              lint_output="$lint_output\n$output"
+            fi
+          done
+          
+          if [ -n "$lint_output" ]; then
+            echo "Linting issues found:"
+            echo -e "$lint_output"
+            exit 1
+          else
+            echo "No linting issues found."
+          fi
+      - name: Run gofmt
+        run: |
+          # Find all .go files and check if they are properly formatted
+          unformatted=$(gofmt -l $(find . -name "*.go" -not -path "./src/vendor/*"))
+          if [ -n "$unformatted" ]; then
+            echo "The following files are not formatted:"
+            echo "$unformatted"
+            exit 1
+          else
+            echo "All files are properly formatted."
+          fi
+
+      - name: Validate SAM Templates
+        run: |
+          for template in $(find . -name ".yaml" -o -name ".yml"); do
+          echo "Validating template: $template"
+          sam validate --template-file "$template" --region us-east-2 --lint
+          done
+  security:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Run CFN Nag Security Checks
+        uses: stelligent/cfn_nag@master
+        with:
+          input_path: .
+          extra_args: -o sarif
+          output_path: cfn_nag.sarif
+      - name: Upload CFN Nag SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: cfn_nag.sarif
+          category: security
+
+  trivy-scan:
+    name: Trivy security scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run Trivy vulnerability scanner in repo mode for Low Priority
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: fs
+          ignore-unfixed: true
+          severity: 'LOW,MEDIUM'
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db
+      - name: Run Trivy vulnerability scanner in repo mode for High Priority
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: fs
+          ignore-unfixed: true
+          exit-code: 1
+          severity: 'HIGH,CRITICAL'
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db
+
+  test-and-coverage:
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -22,118 +115,16 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.22'
-
-      - name: Build and Package Go executable
+      #scripts to include the integration and end to end tests should be added here
+      - name: Run Test Cases and Coverage
         run: |
           cd src
-          go mod tidy
-          GOOS=linux GOARCH=amd64 go build -o bootstrap main.go
-          zip -r ../$log_forwarder_zip_file_name .
-          cd ..
+          mkdir -p coverage
+          go test -race -coverprofile=coverage/coverage.out ./...
+          go tool cover -html=coverage/coverage.out -o coverage/coverage.html
 
-      - name: Upload artifact
+      - name: Upload Coverage Report
         uses: actions/upload-artifact@v3
         with:
-          name: log-forwarder-zip
-          path: |
-            ${{ env.log_forwarder_zip_file_name }}
-
-      - name: Install AWS SAM CLI
-        run: |
-          pip install aws-sam-cli
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v3
-        with:
-          role-to-assume: ${{ secrets.AWS_S3_PUBLISH_ROLE_TEMP }}
-          aws-region: us-east-2
-
-      - name: Build and Package SAM Application and Upload to S3
-        env:
-          bucket_name: anusha-test-ansuha
-          region: us-east-1
-        run: |
-          BUILD_DIR_BASE=".aws-sam/build"
-          TEMPLATES=(
-            "logging-lambda-metric-polling.yaml"
-            "logging-lambda-metric-stream.yaml"
-            "logging-firehose-metric-polling.yaml"
-            "logging-firehose-metric-stream.yaml"
-            "logging-lambda-firehose-metric-polling.yaml"
-            "logging-lambda-firehose-metric-stream.yaml"
-            "lambda-template.yaml"
-            "logging-lambda-firehose-template.yaml"
-          )
-          
-          for TEMPLATE_FILE in "${TEMPLATES[@]}"; do
-            BASE_NAME=$(basename "$TEMPLATE_FILE" .yaml)
-            BUILD_DIR=".aws-sam/build/$BASE_NAME"
-
-            sam build --template-file "$TEMPLATE_FILE" --build-dir "$BUILD_DIR"
-            sam package --s3-bucket "$bucket_name" --template-file "$BUILD_DIR/template.yaml" --output-template-file "$BUILD_DIR/$TEMPLATE_FILE"  --region $region
-          
-            aws s3 cp "$BUILD_DIR/$TEMPLATE_FILE" "s3://$bucket_name/$TEMPLATE_FILE"
-          done
-            
-
-  deploy-lambda-code-parallelly-to-all-region:
-    needs: build-and-deploy
-    permissions:
-      id-token: write
-      contents: write
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        region:
-          - us-east-1
-          - us-east-2
-    #          - eu-west-1
-    #          - eu-west-2
-    #          - us-west-1
-    #          - us-west-2
-    #          - af-south-1
-    #          - ap-east-1
-    #          - ap-south-2
-    #          - ap-southeast-3
-    #          - ap-southeast-5
-    #          - ap-southeast-4
-    #          - ap-south-1
-    #          - ap-northeast-3
-    #          - ap-northeast-2
-    #          - ap-southeast-1
-    #          - ap-southeast-2
-    #          - ap-northeast-1
-    #          - ca-central-1
-    #          - ca-west-1
-    #          - eu-central-1
-    #          - eu-south-1
-    #          - eu-west-3
-    #          - eu-south-2
-    #          - eu-north-1
-    #          - eu-central-2
-    #          - me-south-1
-    #          - me-central-1
-    #          - il-central-1
-    #          - sa-east-1
-
-    steps:
-      - name: Download Artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: log-forwarder-zip
-          path: ./build-artifacts
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v3
-        with:
-          role-to-assume: ${{ secrets.AWS_S3_PUBLISH_ROLE_TEMP }}
-          aws-region: us-east-2
-
-      - name: Upload lambda code to S3 buckets in all AWS region
-        env:
-          bucket_prefix: new-relic-log-forwarder-folder
-          region: ${{ matrix.region }}
-        run: |
-          bucket_name="unified-logging-lambda-code-test-$region"
-          aws s3 cp "./build-artifacts/$log_forwarder_zip_file_name" "s3://$bucket_name/$bucket_prefix/" --region "$region"
-          echo "Deploying $log_forwarder_zip_file_name to region $REGION"
+          name: coverage-report
+          path: src/coverage/coverage.html

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -92,7 +92,7 @@ jobs:
           bucket_prefix: new-relic-log-forwarder-folder
           region: ${{ matrix.region }}
         run: |
-          bucket_name="unified-logging-lambda-code-test-${region}"
+          bucket_name="unified-logging-lambda-code-test-$region"
           aws s3 cp "./build-artifacts/$log_forwarder_zip_file_name" "s3://$bucket_name/$bucket_prefix/" --region "$region"
           echo "Deploying $log_forwarder_zip_file_name to region $REGION"
 

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: log-forwarder-zip
-          path: $log_forwarder_zip_file_name
+          path: ${{ env.log_forwarder_zip_file_name }}
 
   deploy-lambda-code:
     needs: build

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -32,9 +32,37 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: log-forwarder-zip
-          path: ${{ env.log_forwarder_zip_file_name }}
+          path: |
+            ${{ env.log_forwarder_zip_file_name }}
 
-  deploy-lambda-code:
+      - name: Install AWS SAM CLI
+        run: |
+          pip install aws-sam-cli
+
+      - name: Build and Package SAM Application and Upload to S3
+        env:
+          bucket_name: anusha-test-ansuha
+          region: us-east-1
+        run: |
+          TEMPLATES=(
+            "logging-lambda-metric-polling.yaml"
+            "logging-lambda-metric-stream.yaml"
+            "logging-firehose-metric-polling.yaml"
+            "logging-firehose-metric-stream.yaml"
+            "logging-lambda-firehose-metric-polling.yaml"
+            "logging-lambda-firehose-metric-stream.yaml"
+            "lambda-template.yaml"
+            "logging-lambda-firehose-template.yaml"
+          )
+          
+          for TEMPLATE_FILE in "${TEMPLATES[@]}"; do
+            sam build --template-file "$TEMPLATE_FILE"
+            sam package --s3-bucket "$bucket_name" --template-file "template.yaml" --output-template-file "$TEMPLATE_FILE"
+            aws s3 cp "$TEMPLATE_FILE" "s3://$bucket_name/$TEMPLATE_FILE"
+          done
+            
+
+  deploy-lambda-code-parallelly-to-all-region:
     needs: build
     permissions:
       id-token: write
@@ -95,37 +123,3 @@ jobs:
           bucket_name="unified-logging-lambda-code-test-$region"
           aws s3 cp "./build-artifacts/$log_forwarder_zip_file_name" "s3://$bucket_name/$bucket_prefix/" --region "$region"
           echo "Deploying $log_forwarder_zip_file_name to region $REGION"
-
-  deploy-temaplate-files:
-    needs: deploy-lambda-code
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install AWS SAM CLI
-        run: |
-          pip install aws-sam-cli
-
-      - name: Build and Package SAM Application and Upload to S3
-        env:
-          bucket_name: anusha-test-ansuha
-          region: us-east-1
-        run: |
-          TEMPLATES=(
-            "logging-lambda-metric-polling.yaml"
-            "logging-lambda-metric-stream.yaml"
-            "logging-firehose-metric-polling.yaml"
-            "logging-firehose-metric-stream.yaml"
-            "logging-lambda-firehose-metric-polling.yaml"
-            "logging-lambda-firehose-metric-stream.yaml"
-            "lambda-template.yaml"
-            "logging-lambda-firehose-template.yaml"
-          )
-          
-          for TEMPLATE_FILE in "${TEMPLATES[@]}"; do
-            BASE_NAME=$(basename "$TEMPLATE_FILE" .yaml)
-            BUILD_DIR=".aws-sam/build/$BASE_NAME"
-
-            sam build --template-file "$TEMPLATE_FILE" --build-dir "$BUILD_DIR"
-            sam package --s3-bucket "$bucket_name" --template-file "$BUILD_DIR/template.yaml" --output-template-file "$BUILD_DIR/$TEMPLATE_FILE"
-            
-            aws s3 cp "$BUILD_DIR/$TEMPLATE_FILE" "s3://$bucket_name/$TEMPLATE_FILE"
-          done

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -25,14 +25,14 @@ jobs:
           cd src
           go mod tidy
           GOOS=linux GOARCH=amd64 go build -o bootstrap main.go
-          zip -r ../build/$log_forwarder_zip_file_name .
+          zip -r ../$log_forwarder_zip_file_name .
           cd ..
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
           name: log-forwarder-zip
-          path: build
+          path: $log_forwarder_zip_file_name
 
   deploy-lambda-code:
     needs: build

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -44,6 +44,7 @@ jobs:
           bucket_name: anusha-test-ansuha
           region: us-east-1
         run: |
+          BUILD_DIR_BASE=".aws-sam/build"
           TEMPLATES=(
             "logging-lambda-metric-polling.yaml"
             "logging-lambda-metric-stream.yaml"
@@ -56,9 +57,13 @@ jobs:
           )
           
           for TEMPLATE_FILE in "${TEMPLATES[@]}"; do
-            sam build --template-file "$TEMPLATE_FILE"
-            sam package --s3-bucket "$bucket_name" --template-file ".aws-sam/build/template.yaml" --output-template-file "$TEMPLATE_FILE" --region $region
-            aws s3 cp "$TEMPLATE_FILE" "s3://$bucket_name/$TEMPLATE_FILE"
+            BASE_NAME=$(basename "$TEMPLATE_FILE" .yaml)
+            BUILD_DIR=".aws-sam/build/$BASE_NAME"
+
+            sam build --template-file "$TEMPLATE_FILE" --build-dir "$BUILD_DIR"
+            sam package --s3-bucket "$bucket_name" --template-file "$BUILD_DIR/template.yaml" --output-template-file "$BUILD_DIR/$TEMPLATE_FILE"  --region $region
+          
+            aws s3 cp "$BUILD_DIR/$TEMPLATE_FILE" "s3://$bucket_name/$TEMPLATE_FILE"
           done
             
 

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -57,7 +57,7 @@ jobs:
           
           for TEMPLATE_FILE in "${TEMPLATES[@]}"; do
             sam build --template-file "$TEMPLATE_FILE"
-            sam package --s3-bucket "$bucket_name" --template-file "template.yaml" --output-template-file "$TEMPLATE_FILE"
+            sam package --s3-bucket "$bucket_name" --template-file ".aws-sam/build/template.yaml" --output-template-file "$TEMPLATE_FILE"
             aws s3 cp "$TEMPLATE_FILE" "s3://$bucket_name/$TEMPLATE_FILE"
           done
             

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -9,8 +9,11 @@ env:
   log_forwarder_zip_file_name: new-relic-log-forwarder.zip
 
 jobs:
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -39,6 +42,12 @@ jobs:
         run: |
           pip install aws-sam-cli
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          role-to-assume: ${{ secrets.AWS_S3_PUBLISH_ROLE_TEMP }}
+          aws-region: us-east-2
+
       - name: Build and Package SAM Application and Upload to S3
         env:
           bucket_name: anusha-test-ansuha
@@ -64,11 +73,9 @@ jobs:
             sam package --s3-bucket "$bucket_name" --template-file "$BUILD_DIR/template.yaml" --output-template-file "$BUILD_DIR/$TEMPLATE_FILE"  --region $region
           
             aws s3 cp "$BUILD_DIR/$TEMPLATE_FILE" "s3://$bucket_name/$TEMPLATE_FILE"
-          done
-            
+          done  
 
   deploy-lambda-code-parallelly-to-all-region:
-    needs: build
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -57,7 +57,7 @@ jobs:
           
           for TEMPLATE_FILE in "${TEMPLATES[@]}"; do
             sam build --template-file "$TEMPLATE_FILE"
-            sam package --s3-bucket "$bucket_name" --template-file ".aws-sam/build/template.yaml" --output-template-file "$TEMPLATE_FILE"
+            sam package --s3-bucket "$bucket_name" --template-file ".aws-sam/build/template.yaml" --output-template-file "$TEMPLATE_FILE" --region $region
             aws s3 cp "$TEMPLATE_FILE" "s3://$bucket_name/$TEMPLATE_FILE"
           done
             

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -1,7 +1,7 @@
 name: Build and Deploy Lambda
 
 on:
-  push:
+  pull_request:
     branches:
       - main
 

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -121,7 +121,11 @@ jobs:
           )
           
           for TEMPLATE_FILE in "${TEMPLATES[@]}"; do
-            sam build --template-file "$TEMPLATE_FILE"
-            sam package --s3-bucket "$bucket_name" --template-file ".aws-sam/build/template.yaml" --output-template-file "$TEMPLATE_FILE" --region $region
-            aws s3 cp "$TEMPLATE_FILE" "s3://$bucket_name/$TEMPLATE_FILE"
+            BASE_NAME=$(basename "$TEMPLATE_FILE" .yaml)
+            BUILD_DIR=".aws-sam/build/$BASE_NAME"
+
+            sam build --template-file "$TEMPLATE_FILE" --build-dir "$BUILD_DIR"
+            sam package --s3-bucket "$bucket_name" --template-file "$BUILD_DIR/template.yaml" --output-template-file "$BUILD_DIR/$TEMPLATE_FILE"
+            
+            aws s3 cp "$BUILD_DIR/$TEMPLATE_FILE" "s3://$bucket_name/$TEMPLATE_FILE"
           done

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,8 +77,8 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v3
         with:
-          role-to-assume: ${{ secrets.AWS_SAR_PUBLISHER_ROLE }}
-          aws-region: us-east-1
+          role-to-assume: ${{ secrets.AWS_S3_PUBLISH_ROLE_TEMP }}
+          aws-region: us-east-2
 
       - name: Upload lambda code to S3 buckets in all AWS region
         env:
@@ -102,7 +102,6 @@ jobs:
           bucket_name: anusha-test-ansuha
           region: us-east-1
         run: |
-          BUILD_DIR_BASE=".aws-sam/build"
           TEMPLATES=(
             "logging-lambda-metric-polling.yaml"
             "logging-lambda-metric-stream.yaml"
@@ -115,11 +114,7 @@ jobs:
           )
           
           for TEMPLATE_FILE in "${TEMPLATES[@]}"; do
-            BASE_NAME=$(basename "$TEMPLATE_FILE" .yaml)
-            BUILD_DIR="$BUILD_DIR_BASE/$BASE_NAME"
-          
-            sam build --template-file "$TEMPLATE_FILE" --build-dir "$BUILD_DIR"
-            sam package --s3-bucket "$bucket_name" --template-file "$BUILD_DIR/template.yaml" --output-template-file "$BUILD_DIR/$TEMPLATE_FILE" --region $region
-          
-            aws s3 cp "$BUILD_DIR/$TEMPLATE_FILE" "s3://$bucket_name/$TEMPLATE_FILE"
+            sam build --template-file "$TEMPLATE_FILE"
+            sam package --s3-bucket "$bucket_name" --template-file "template.yaml" --output-template-file "$TEMPLATE_FILE" --region $region
+            aws s3 cp "$TEMPLATE_FILE" "s3://$bucket_name/$TEMPLATE_FILE"
           done

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,15 +26,49 @@ jobs:
           role-to-assume: ${{ secrets.AWS_SAR_PUBLISHER_ROLE }}
           aws-region: us-east-2
 
+      - name: Build and Package Go executable
+        run: |
+          cd src
+          GOOS=linux GOARCH=amd64 go build -o bootstrap main.go
+          zip -r ../new-relic-log-forwarder.zip .
+
+      - name: Upload lambda code to S3 buckets in all AWS region
+        env:
+          file_to_upload: new-relic-log-forwarder.zip
+        run: |
+          regions=("us-east-1" "us-east-2" "eu-west-1" "eu-west-2")
+          #"us-west-1" "us-west-2" "af-south-1" "ap-east-1" "ap-south-2" "ap-southeast-3" "ap-southeast-5" "ap-southeast-4" "ap-south-1" "ap-northeast-3" "ap-northeast-2" "ap-southeast-1" "ap-southeast-2" "ap-northeast-1" "ca-central-1" "ca-west-1" "eu-central-1" "eu-south-1" "eu-west-3" "eu-south-2" "eu-north-1" "eu-central-2" "me-south-1" "me-central-1" "il-central-1" "sa-east-1")
+          for region in "${regions[@]}"; do
+            bucket_name="unified-lambda-logging-${region}"
+            aws s3 cp "$file_to_upload" "s3://$bucket_name/new-relic-log-forwarder-folder/" --region "$region"
+          done
+
       - name: Install AWS SAM CLI
         run: |
           pip install aws-sam-cli
 
-      - name: Build SAM Application
-        run: sam build --template-file template.yaml --region us-east-2
-
-      - name: Package SAM Application
-        run: sam package --s3-bucket unified-lambda-cft-1 --output-template-file packaged.yaml --region us-east-2
-# should we include retries as part of uploading?
-      - name: Upload CloudFormation Template to S3
-        run: aws s3 cp packaged.yaml s3://unified-lambda-serverless-1/packaged.yaml
+      - name: Build and Package SAM Application and Upload to S3
+        env:
+          bucket_name: anusha-test-ansuha
+        run: |
+          BUILD_DIR_BASE=".aws-sam/build"
+          TEMPLATES=(
+            "logging-lambda-metric-polling.yaml"
+            "logging-lambda-metric-stream.yaml"
+            "logging-firehose-metric-polling.yaml"
+            "logging-firehose-metric-stream.yaml"
+            "logging-lambda-firehose-metric-polling.yaml"
+            "logging-lambda-firehose-metric-stream.yaml"
+            "lambda-template.yaml"
+            "logging-lambda-firehose-template.yaml"
+          )
+          
+          for TEMPLATE_FILE in "${TEMPLATES[@]}"; do
+            BASE_NAME=$(basename "$TEMPLATE_FILE" .yaml)
+            BUILD_DIR="$BUILD_DIR_BASE/$BASE_NAME"
+          
+            sam build --template-file "$TEMPLATE_FILE" --build-dir "$BUILD_DIR"
+            sam package --s3-bucket "$bucket_name" --template-file "$BUILD_DIR/template.yaml" --output-template-file "$BUILD_DIR/$TEMPLATE_FILE" --region us-east-1
+          
+            aws s3 cp "$BUILD_DIR/$TEMPLATE_FILE" "s3://$bucket_name/$TEMPLATE_FILE"
+          done

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,14 +25,14 @@ jobs:
           cd src
           go mod tidy
           GOOS=linux GOARCH=amd64 go build -o bootstrap main.go
-          zip -r ../$log_forwarder_zip_file_name .
+          zip -r ../build/$log_forwarder_zip_file_name .
           cd ..
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
           name: log-forwarder-zip
-          path: log_forwarder_zip_file_name
+          path: build
 
   deploy-lambda-code:
     needs: build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,7 @@
 name: Build and Deploy Lambda
 
 on:
-  push:
+  pull_request:
     branches:
       - main
 
@@ -9,8 +9,11 @@ env:
   log_forwarder_zip_file_name: new-relic-log-forwarder.zip
 
 jobs:
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -25,83 +28,32 @@ jobs:
           cd src
           go mod tidy
           GOOS=linux GOARCH=amd64 go build -o bootstrap main.go
-          zip -r ../build/$log_forwarder_zip_file_name .
+          zip -r ../$log_forwarder_zip_file_name .
           cd ..
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
           name: log-forwarder-zip
-          path: build
+          path: |
+            ${{ env.log_forwarder_zip_file_name }}
 
-  deploy-lambda-code:
-    needs: build
-    permissions:
-      id-token: write
-      contents: write
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        region:
-          - us-east-1
-          - us-east-2
-#          - eu-west-1
-#          - eu-west-2
-#          - us-west-1
-#          - us-west-2
-#          - af-south-1
-#          - ap-east-1
-#          - ap-south-2
-#          - ap-southeast-3
-#          - ap-southeast-5
-#          - ap-southeast-4
-#          - ap-south-1
-#          - ap-northeast-3
-#          - ap-northeast-2
-#          - ap-southeast-1
-#          - ap-southeast-2
-#          - ap-northeast-1
-#          - ca-central-1
-#          - ca-west-1
-#          - eu-central-1
-#          - eu-south-1
-#          - eu-west-3
-#          - eu-south-2
-#          - eu-north-1
-#          - eu-central-2
-#          - me-south-1
-#          - me-central-1
-#          - il-central-1
-#          - sa-east-1
-    steps:
+      - name: Install AWS SAM CLI
+        run: |
+          pip install aws-sam-cli
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: ${{ secrets.AWS_S3_PUBLISH_ROLE_TEMP }}
           aws-region: us-east-2
 
-      - name: Upload lambda code to S3 buckets in all AWS region
-        env:
-          bucket_prefix: new-relic-log-forwarder-folder
-          region: ${{ matrix.region }}
-        run: |
-          bucket_name="unified-logging-lambda-code-test-${region}"
-          aws s3 cp "$log_forwarder_zip_file_name" "s3://$bucket_name/$bucket_prefix/" --region "$region"
-          echo "Deploying $log_forwarder_zip_file_name to region $REGION"
-
-  deploy-temaplate-files:
-    needs: deploy-lambda-code
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install AWS SAM CLI
-        run: |
-          pip install aws-sam-cli
-
       - name: Build and Package SAM Application and Upload to S3
         env:
           bucket_name: anusha-test-ansuha
           region: us-east-1
         run: |
+          BUILD_DIR_BASE=".aws-sam/build"
           TEMPLATES=(
             "logging-lambda-metric-polling.yaml"
             "logging-lambda-metric-stream.yaml"
@@ -122,3 +74,66 @@ jobs:
           
             aws s3 cp "$BUILD_DIR/$TEMPLATE_FILE" "s3://$bucket_name/$TEMPLATE_FILE"
           done
+  
+
+  deploy-lambda-code-parallelly-to-all-region:
+    needs: build-and-deploy
+    permissions:
+      id-token: write
+      contents: write
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        region:
+          - us-east-1
+          - us-east-2
+    #          - eu-west-1
+    #          - eu-west-2
+    #          - us-west-1
+    #          - us-west-2
+    #          - af-south-1
+    #          - ap-east-1
+    #          - ap-south-2
+    #          - ap-southeast-3
+    #          - ap-southeast-5
+    #          - ap-southeast-4
+    #          - ap-south-1
+    #          - ap-northeast-3
+    #          - ap-northeast-2
+    #          - ap-southeast-1
+    #          - ap-southeast-2
+    #          - ap-northeast-1
+    #          - ca-central-1
+    #          - ca-west-1
+    #          - eu-central-1
+    #          - eu-south-1
+    #          - eu-west-3
+    #          - eu-south-2
+    #          - eu-north-1
+    #          - eu-central-2
+    #          - me-south-1
+    #          - me-central-1
+    #          - il-central-1
+    #          - sa-east-1
+
+    steps:
+      - name: Download Artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: log-forwarder-zip
+          path: ./build-artifacts
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          role-to-assume: ${{ secrets.AWS_S3_PUBLISH_ROLE_TEMP }}
+          aws-region: us-east-2
+
+      - name: Upload lambda code to S3 buckets in all AWS region
+        env:
+          bucket_prefix: new-relic-log-forwarder-folder
+          region: ${{ matrix.region }}
+        run: |
+          bucket_name="unified-logging-lambda-code-test-$region"
+          aws s3 cp "./build-artifacts/$log_forwarder_zip_file_name" "s3://$bucket_name/$bucket_prefix/" --region "$region"
+          echo "Deploying $log_forwarder_zip_file_name to region $REGION"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,8 +5,11 @@ on:
     branches:
       - main
 
+env:
+  log_forwarder_zip_file_name: new-relic-log-forwarder.zip
+
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -20,29 +23,76 @@ jobs:
         with:
           go-version: '1.22'
 
+      - name: Build and Package Go executable
+        run: |
+          cd src
+          go mod tidy
+          GOOS=linux GOARCH=amd64 go build -o bootstrap main.go
+          zip -r ../$log_forwarder_zip_file_name .
+          cd ..
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: log-forwarder-zip
+          path: log_forwarder_zip_file_name
+
+  deploy-lambda-code:
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        region:
+          - us-east-1
+          - us-east-2
+#          - eu-west-1
+#          - eu-west-2
+#          - us-west-1
+#          - us-west-2
+#          - af-south-1
+#          - ap-east-1
+#          - ap-south-2
+#          - ap-southeast-3
+#          - ap-southeast-5
+#          - ap-southeast-4
+#          - ap-south-1
+#          - ap-northeast-3
+#          - ap-northeast-2
+#          - ap-southeast-1
+#          - ap-southeast-2
+#          - ap-northeast-1
+#          - ca-central-1
+#          - ca-west-1
+#          - eu-central-1
+#          - eu-south-1
+#          - eu-west-3
+#          - eu-south-2
+#          - eu-north-1
+#          - eu-central-2
+#          - me-south-1
+#          - me-central-1
+#          - il-central-1
+#          - sa-east-1
+    steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: ${{ secrets.AWS_SAR_PUBLISHER_ROLE }}
-          aws-region: us-east-2
-
-      - name: Build and Package Go executable
-        run: |
-          cd src
-          GOOS=linux GOARCH=amd64 go build -o bootstrap main.go
-          zip -r ../new-relic-log-forwarder.zip .
+          aws-region: us-east-1
 
       - name: Upload lambda code to S3 buckets in all AWS region
         env:
-          file_to_upload: new-relic-log-forwarder.zip
+          bucket_prefix: new-relic-log-forwarder-folder
+          region: ${{ matrix.region }}
         run: |
-          regions=("us-east-1" "us-east-2" "eu-west-1" "eu-west-2")
-          #"us-west-1" "us-west-2" "af-south-1" "ap-east-1" "ap-south-2" "ap-southeast-3" "ap-southeast-5" "ap-southeast-4" "ap-south-1" "ap-northeast-3" "ap-northeast-2" "ap-southeast-1" "ap-southeast-2" "ap-northeast-1" "ca-central-1" "ca-west-1" "eu-central-1" "eu-south-1" "eu-west-3" "eu-south-2" "eu-north-1" "eu-central-2" "me-south-1" "me-central-1" "il-central-1" "sa-east-1")
-          for region in "${regions[@]}"; do
-            bucket_name="unified-lambda-logging-${region}"
-            aws s3 cp "$file_to_upload" "s3://$bucket_name/new-relic-log-forwarder-folder/" --region "$region"
-          done
+          bucket_name="unified-logging-lambda-code-test-${region}"
+          aws s3 cp "$log_forwarder_zip_file_name" "s3://$bucket_name/$bucket_prefix/" --region "$region"
+          echo "Deploying $log_forwarder_zip_file_name to region $REGION"
 
+  deploy-temaplate-files:
+    needs: deploy-lambda-code
+    runs-on: ubuntu-latest
+    steps:
       - name: Install AWS SAM CLI
         run: |
           pip install aws-sam-cli
@@ -50,6 +100,7 @@ jobs:
       - name: Build and Package SAM Application and Upload to S3
         env:
           bucket_name: anusha-test-ansuha
+          region: us-east-1
         run: |
           BUILD_DIR_BASE=".aws-sam/build"
           TEMPLATES=(
@@ -68,7 +119,7 @@ jobs:
             BUILD_DIR="$BUILD_DIR_BASE/$BASE_NAME"
           
             sam build --template-file "$TEMPLATE_FILE" --build-dir "$BUILD_DIR"
-            sam package --s3-bucket "$bucket_name" --template-file "$BUILD_DIR/template.yaml" --output-template-file "$BUILD_DIR/$TEMPLATE_FILE" --region us-east-1
+            sam package --s3-bucket "$bucket_name" --template-file "$BUILD_DIR/template.yaml" --output-template-file "$BUILD_DIR/$TEMPLATE_FILE" --region $region
           
             aws s3 cp "$BUILD_DIR/$TEMPLATE_FILE" "s3://$bucket_name/$TEMPLATE_FILE"
           done

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -118,7 +118,7 @@ jobs:
             BUILD_DIR=".aws-sam/build/$BASE_NAME"
 
             sam build --template-file "$TEMPLATE_FILE" --build-dir "$BUILD_DIR"
-            sam package --s3-bucket "$bucket_name" --template-file "$BUILD_DIR/template.yaml" --output-template-file "$BUILD_DIR/$TEMPLATE_FILE"
+            sam package --s3-bucket "$bucket_name" --template-file "$BUILD_DIR/template.yaml" --output-template-file "$BUILD_DIR/$TEMPLATE_FILE"  --region $region
           
             aws s3 cp "$BUILD_DIR/$TEMPLATE_FILE" "s3://$bucket_name/$TEMPLATE_FILE"
           done

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -114,7 +114,11 @@ jobs:
           )
           
           for TEMPLATE_FILE in "${TEMPLATES[@]}"; do
-            sam build --template-file "$TEMPLATE_FILE"
-            sam package --s3-bucket "$bucket_name" --template-file "template.yaml" --output-template-file "$TEMPLATE_FILE" --region $region
-            aws s3 cp "$TEMPLATE_FILE" "s3://$bucket_name/$TEMPLATE_FILE"
+            BASE_NAME=$(basename "$TEMPLATE_FILE" .yaml)
+            BUILD_DIR=".aws-sam/build/$BASE_NAME"
+
+            sam build --template-file "$TEMPLATE_FILE" --build-dir "$BUILD_DIR"
+            sam package --s3-bucket "$bucket_name" --template-file "$BUILD_DIR/template.yaml" --output-template-file "$BUILD_DIR/$TEMPLATE_FILE"
+          
+            aws s3 cp "$BUILD_DIR/$TEMPLATE_FILE" "s3://$bucket_name/$TEMPLATE_FILE"
           done

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,9 +11,6 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -39,6 +36,9 @@ jobs:
 
   deploy-lambda-code:
     needs: build
+    permissions:
+      id-token: write
+      contents: write
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
In github release workflow add step to build and deploy lambda code to all regions S3 bucket and push it to logint's AWS account along with templates. 

Note -> The S3 buckets created and added in the workflow are test buckets. Once the IAM role for Jim Ruppert account is created the workflow will have production buckets added. 

Tests run:
1. deployed firehose-lambda-template in us-east-2. Stack name -> anusha-ci-cd-test-lambda-firehose-template. Logs populated in nr. 
2. deployed lambda-template in eu-west-1. Stack name -> anusha-ci-cd-test-lambda-template. Logs populated in nr 

<img width="1098" alt="Screenshot 2024-11-28 at 7 15 54 PM" src="https://github.com/user-attachments/assets/4741740f-0e5b-46d8-a892-a2cbf1c4c21b">

Check the workflow run here successfully -> https://github.com/newrelic/aws-unified-lambda/pull/1/checks?check_run_id=33904514146
