### PR TITLE
Rename logObjectURI to logObjectKey

### DIFF
--- a/integration-tests/common/config.go
+++ b/integration-tests/common/config.go
@@ -17,8 +17,8 @@ const (
 	ExecutableFileName = "main"
 	// NewRelicRegion region where lambda is deployed
 	NewRelicRegion = "US"
-	// LogObjectURI parameter of entity synthesis
-	LogObjectURI = "logObjectURI"
+	// LogObjectKey parameter of entity synthesis
+	LogObjectKey = "logObjectKey"
 	// FetchLogsTimeRange time range used in query to fetch logs
 	FetchLogsTimeRange = "30 seconds"
 	// NoOfRetriesForEventCreation number of retries while creating resources
@@ -46,7 +46,7 @@ type LogEvent struct {
 	InstrumentationName     string `json:"instrumentation.name"`
 	InstrumentationProvider string `json:"instrumentation.provider"`
 	LogBucketName           string `json:"logBucketName"`
-	LogObjectURI            string `json:"logObjectURI"`
+	LogObjectKey            string `json:"logObjectKey"`
 	Message                 string `json:"message"`
 	NewRelicLogPattern      string `json:"newrelic.logPattern"`
 	NewRelicSource          string `json:"newrelic.source"`

--- a/integration-tests/helpers/newRelicLogsFetcherHelper.go
+++ b/integration-tests/helpers/newRelicLogsFetcherHelper.go
@@ -3,18 +3,19 @@ package helpers
 import (
 	"bytes"
 	"encoding/json"
-	integrationtests "github.com/newrelic/aws-unified-lambda-logging/common"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"strconv"
+
+	integrationtests "github.com/newrelic/aws-unified-lambda-logging/common"
 )
 
 // FetchLogsFromNewRelic function to fetch logs
 func FetchLogsFromNewRelic(userKey, accountID, fileName string) ([]integrationtests.LogEvent, error) {
 	// setup
 	accountIDTemp, _ := strconv.ParseInt(accountID, 10, 32)
-	nrqlQuery := "SELECT * FROM Log SINCE " + integrationtests.FetchLogsTimeRange + " ago WHERE " + integrationtests.LogObjectURI + " LIKE '" + fileName + "'"
+	nrqlQuery := "SELECT * FROM Log SINCE " + integrationtests.FetchLogsTimeRange + " ago WHERE " + integrationtests.LogObjectKey + " LIKE '" + fileName + "'"
 	variables := map[string]interface{}{
 		"id":   int(accountIDTemp),
 		"nrql": nrqlQuery,

--- a/src/s3/s3.go
+++ b/src/s3/s3.go
@@ -41,7 +41,7 @@ func GetLogsFromS3Event(ctx context.Context, s3Event events.S3Event, awsConfigur
 		attributes := common.LogAttributes{
 			"aws.accountId":            awsConfiguration.AccountID,
 			"logBucketName":            record.S3.Bucket.Name,
-			"logObjectURI":             record.S3.Object.URLDecodedKey,
+			"logObjectKey":             record.S3.Object.URLDecodedKey,
 			"aws.realm":                awsConfiguration.Realm,
 			"aws.region":               awsConfiguration.Region,
 			"instrumentation.provider": common.InstrumentationProvider,


### PR DESCRIPTION
The term logObjectURI is ambiguous: it should be logObjectKey (as in [object key](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html)). 

Internal Issue# NR-344890

![Screenshot 2024-12-03 at 6 09 57 PM](https://github.com/user-attachments/assets/e48dc5b1-db79-4d12-b5b0-564379e16193)
