### PR TITLE
deleting trigger and filters created as part of stack deletion

### DIFF
--- a/lambda-cloudwatch-trigger-stack.yaml
+++ b/lambda-cloudwatch-trigger-stack.yaml
@@ -118,7 +118,7 @@ Resources:
                           add_permission_if_needed(event,context,lambda_arn, log_group_arn, log_group_name)
 
                           # Unique filter name for this stack using Lambda ARN
-                          filter_name = f'LambdaSubscription_{hashlib.sha256(lambda_arn.encode()).hexdigest()[:20]}'
+                          filter_name = f'NewRelicLogsLambdaSubscription_{hashlib.sha256(lambda_arn.encode()).hexdigest()[:20]}'
 
                           # Retry logic for PutSubscriptionFilter                       
                           max_retries = 5
@@ -152,7 +152,7 @@ Resources:
                                   continue
                           
                               # Unique filter name for this stack using Lambda ARN
-                              filter_name = f'LambdaSubscription_{hashlib.sha256(lambda_arn.encode()).hexdigest()[:20]}'
+                              filter_name = f'NewRelicLogsLambdaSubscription_{hashlib.sha256(lambda_arn.encode()).hexdigest()[:20]}'
 
                           
                               #remove the subscription filter

--- a/lambda-cloudwatch-trigger-stack.yaml
+++ b/lambda-cloudwatch-trigger-stack.yaml
@@ -54,6 +54,7 @@ Resources:
                   - logs:DescribeLogGroups
                   - logs:DescribeLogStreams
                   - logs:PutSubscriptionFilter
+                  - logs:DeleteSubscriptionFilter
                   - lambda:AddPermission
                 Resource: !Ref LogGroupArns
               - Effect: Allow
@@ -116,6 +117,9 @@ Resources:
 
                           add_permission_if_needed(event,context,lambda_arn, log_group_arn, log_group_name)
 
+                          # Unique filter name for this stack using Lambda ARN
+                          filter_name = f'LambdaSubscription_{hashlib.sha256(lambda_arn.encode()).hexdigest()[:20]}'
+
                           # Retry logic for PutSubscriptionFilter                       
                           max_retries = 5
                           initial_backoff_time_in_seconds = 1                     
@@ -125,7 +129,7 @@ Resources:
                               try:
                                   response = log_client.put_subscription_filter(
                                       logGroupName=log_group_name,
-                                      filterName='LambdaSubscription',
+                                      filterName=filter_name,
                                       filterPattern=filter_pattern,
                                       destinationArn=lambda_arn
                                   )
@@ -138,11 +142,27 @@ Resources:
                                       backoff_time_in_seconds *= backoff_multiplier
                                   else:
                                       cfnresponse.send(event, context, cfnresponse.FAILED, {}, reason=f'{str(e)} - logGroupName: {logGroupName}')
+                  
+                  elif request_type == 'Delete':
+                      for log_group in log_group_config:
+                          log_group_name = log_group['LogGroupName']
+                          if log_group_name in invalid_log_groups:
+                              logger.info(f'Log group {log_group_name} is invalid. Skipping...')
+                              continue
+                          
+                          # Unique filter name for this stack using Lambda ARN
+                          filter_name = f'LambdaSubscription_{hashlib.sha256(lambda_arn.encode()).hexdigest()[:20]}'
 
+                          
+                          #remove the subscription filter
+                          log_client.delete_subscription_filter(
+                              logGroupName=log_group_name,
+                              filterName=filter_name
+                          )
                   cfnresponse.send(event, context, cfnresponse.SUCCESS, response)
               except Exception as e:
                   logger.error(f'Error: {str(e)}')
-                  cfnresponse.send(event, context, cfnresponse.FAILED, {}, reason=f'{str(e)} - LogGroupArn: {log_group_arn}')
+                  cfnresponse.send(event, context, cfnresponse.FAILED, {}, reason=f'{str(e)}')
           
           def add_permission_if_needed(event, context,lambda_arn, log_group_arn, log_group_name):
               try:
@@ -163,7 +183,7 @@ Resources:
                   pass
               except Exception as e:
                   logger.error(f'Error: {str(e)}')
-                  cfnresponse.send(event, context, cfnresponse.FAILED, {}, reason=f'{str(e)} -  LogGroupArn: {log_group_arn}')               
+                  cfnresponse.send(event, context, cfnresponse.FAILED, {}, reason=f'{str(e)}')               
 
       Handler: index.lambda_handler
       Role: !GetAtt NewRelicLogsCloudWatchLambdaIAMRole.Arn

--- a/lambda-cloudwatch-trigger-stack.yaml
+++ b/lambda-cloudwatch-trigger-stack.yaml
@@ -144,21 +144,25 @@ Resources:
                                       cfnresponse.send(event, context, cfnresponse.FAILED, {}, reason=f'{str(e)} - logGroupName: {logGroupName}')
                   
                   elif request_type == 'Delete':
-                      for log_group in log_group_config:
-                          log_group_name = log_group['LogGroupName']
-                          if log_group_name in invalid_log_groups:
-                              logger.info(f'Log group {log_group_name} is invalid. Skipping...')
-                              continue
+                      try:
+                          for log_group in log_group_config:
+                              log_group_name = log_group['LogGroupName']
+                              if log_group_name in invalid_log_groups:
+                                  logger.info(f'Log group {log_group_name} is invalid. Skipping...')
+                                  continue
                           
-                          # Unique filter name for this stack using Lambda ARN
-                          filter_name = f'LambdaSubscription_{hashlib.sha256(lambda_arn.encode()).hexdigest()[:20]}'
+                              # Unique filter name for this stack using Lambda ARN
+                              filter_name = f'LambdaSubscription_{hashlib.sha256(lambda_arn.encode()).hexdigest()[:20]}'
 
                           
-                          #remove the subscription filter
-                          log_client.delete_subscription_filter(
-                              logGroupName=log_group_name,
-                              filterName=filter_name
-                          )
+                              #remove the subscription filter
+                              log_client.delete_subscription_filter(
+                                  logGroupName=log_group_name,
+                                  filterName=filter_name
+                              )
+                      except Exception as e:
+                          logger.error(f'Delete failed for the log group subscription filters with error: {str(e)}')
+                          cfnresponse.send(event, context, cfnresponse.SUCCESS, response)
                   cfnresponse.send(event, context, cfnresponse.SUCCESS, response)
               except Exception as e:
                   logger.error(f'Error: {str(e)}')

--- a/s3-trigger-stack.yaml
+++ b/s3-trigger-stack.yaml
@@ -78,12 +78,11 @@ Resources:
           def lambda_handler(event, context):
               response = {}
               try:
+                  event_data = event['ResourceProperties']          
+                  lambda_arn = event_data.get('LambdaFunctionArn', '')
+                  buckets = event_data.get('S3BucketArns', [])              
                   if event['RequestType'] == 'Delete':
                       try:
-
-                          event_data = event['ResourceProperties']
-                          lambda_arn = event_data.get('LambdaFunctionArn', '')
-                          buckets = event_data.get('S3BucketArns', [])
                           for bucket_arn in buckets:
                               parts = bucket_arn.split(":::")[-1].split("/", 1)
                               bucket_name = parts[0]
@@ -92,6 +91,10 @@ Resources:
                               existing_config = s3.get_bucket_notification_configuration(Bucket=bucket_name)
 
                               existing_lambda_configs = existing_config.get('LambdaFunctionConfigurations', [])
+                              if not existing_lambda_configs:
+                                  continue
+                              
+                              # Deleting the existing configuration
                               updated_lambda_configs = [config for config in existing_lambda_configs if config['LambdaFunctionArn'] != lambda_arn]
  
                               notification_config = {
@@ -104,12 +107,7 @@ Resources:
                       except Exception as e:
                           logger.error(f'Delete failed for the bucket triggers  with error: {str(e)}')
                           cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
-                          return {}
                   else:
-                      event_data = event['ResourceProperties']
-          
-                      lambda_arn = event_data.get('LambdaFunctionArn', '')
-                      buckets = event_data.get('S3BucketArns', [])
                       bucket_where_trigger_exists = []
                       for bucket_arn in buckets:
 

--- a/s3-trigger-stack.yaml
+++ b/s3-trigger-stack.yaml
@@ -79,30 +79,32 @@ Resources:
               response = {}
               try:
                   if event['RequestType'] == 'Delete':
-                      event_data = event['ResourceProperties']
-                      lambda_arn = event_data.get('LambdaFunctionArn', '')
-                      buckets = event_data.get('S3BucketArns', [])
-                      for bucket_arn in buckets:
-                          parts = bucket_arn.split(":::")[-1].split("/", 1)
-                          bucket_name = parts[0]
-                          
-                          # get the existing notification configuration
-                          existing_config = s3.get_bucket_notification_configuration(Bucket=bucket_name)
+                      try:
 
-                          existing_lambda_configs = existing_config.get('LambdaFunctionConfigurations', [])
-                          updated_lambda_configs = [config for config in existing_lambda_configs if config['LambdaFunctionArn'] != lambda_arn]
+                          event_data = event['ResourceProperties']
+                          lambda_arn = event_data.get('LambdaFunctionArn', '')
+                          buckets = event_data.get('S3BucketArns', [])
+                          for bucket_arn in buckets:
+                              parts = bucket_arn.split(":::")[-1].split("/", 1)
+                              bucket_name = parts[0]
+                           
+                              # get the existing notification configuration
+                              existing_config = s3.get_bucket_notification_configuration(Bucket=bucket_name)
 
-                          notification_config = {
-                              'LambdaFunctionConfigurations': updated_lambda_configs
-                          }
-                          s3.put_bucket_notification_configuration(
-                              Bucket=bucket_name,
-                              NotificationConfiguration=notification_config
-                          )
-                          
-                      cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
-                      return {}
-                  
+                              existing_lambda_configs = existing_config.get('LambdaFunctionConfigurations', [])
+                              updated_lambda_configs = [config for config in existing_lambda_configs if config['LambdaFunctionArn'] != lambda_arn]
+ 
+                              notification_config = {
+                                  'LambdaFunctionConfigurations': updated_lambda_configs
+                              }
+                              s3.put_bucket_notification_configuration(
+                                  Bucket=bucket_name,
+                                  NotificationConfiguration=notification_config
+                              )
+                      except Exception as e:
+                          logger.error(f'Delete failed for the bucket triggers  with error: {str(e)}')
+                          cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
+                          return {}
                   else:
                       event_data = event['ResourceProperties']
           
@@ -176,7 +178,7 @@ Resources:
                           .format(','.join(bucket_where_trigger_exists))
                           )
 
-                      cfnresponse.send(event, context, cfnresponse.SUCCESS, response)
+                  cfnresponse.send(event, context, cfnresponse.SUCCESS, response)
               except Exception as e:
                   logger.error(f'Error: {str(e)}')
                   cfnresponse.send(event, context, cfnresponse.FAILED, {}, reason=f'{str(e)} ')

--- a/s3-trigger-stack.yaml
+++ b/s3-trigger-stack.yaml
@@ -79,6 +79,27 @@ Resources:
               response = {}
               try:
                   if event['RequestType'] == 'Delete':
+                      event_data = event['ResourceProperties']
+                      lambda_arn = event_data.get('LambdaFunctionArn', '')
+                      buckets = event_data.get('S3BucketArns', [])
+                      for bucket_arn in buckets:
+                          parts = bucket_arn.split(":::")[-1].split("/", 1)
+                          bucket_name = parts[0]
+                          
+                          # get the existing notification configuration
+                          existing_config = s3.get_bucket_notification_configuration(Bucket=bucket_name)
+
+                          existing_lambda_configs = existing_config.get('LambdaFunctionConfigurations', [])
+                          updated_lambda_configs = [config for config in existing_lambda_configs if config['LambdaFunctionArn'] != lambda_arn]
+
+                          notification_config = {
+                              'LambdaFunctionConfigurations': updated_lambda_configs
+                          }
+                          s3.put_bucket_notification_configuration(
+                              Bucket=bucket_name,
+                              NotificationConfiguration=notification_config
+                          )
+                          
                       cfnresponse.send(event, context, cfnresponse.SUCCESS, {})
                       return {}
                   


### PR DESCRIPTION
After this code changes:
1. On stack deletion, we will delete any S3 trigger event notification created as part of this particular stack.
2. On stack deletion, we will delete any subscription filter created on any log group created as part of this particular stack

Testing:
1. Create a stack, give a S3 bucket name, see that event notification are created. Delete the stack, event notification should also be deleted.
2. Take a S3 bucket, create a sample event trigger for some other event type other than s3:ObjectCreated:*, Now go and create a cloud formation stack here give the same S3 bucket name. Now go and check that there will be 2 event notification on this bucket. Delete the Cloud formation stack. Only the second event notification should get deleted. Any event notification created before stack creation should not get deleted. 
3. Create a stack with selecting log group name, see that a subscription filter is created. Delete the stack, the subscription filter should be deleted.
4. Take a log group with existing subscription filter already present. Create a cloud formation stack with this particular stack, see that second subscription filter get created. Now delete this stack, only the second subscription filter should be deleted. The subscription filter created prior to our stack creation should not get deleted.
5. It is working for prefix as well. Here is how I tested:
- Create a bucket B1. and then create two folders (prefix) inside P1 and P2.
- Go and manually add trigger for P1 and point it to some lambda xyz.
- Now create a stack and give bucket B1 and prefix P2.
- You can see two triggers for the bucket.
- Delete the stack, only the trigger for P2 will be deleted since this will be associated with our lambda.