### PR TITLE
[NR-344385] Support deployment of lambda templates from local setup

### DIFF
--- a/.github/workflows/release-template-files.yaml
+++ b/.github/workflows/release-template-files.yaml
@@ -26,6 +26,15 @@ jobs:
         run: |
           pip install aws-sam-cli
 
+      - name: Prepare Template for S3 Deployment
+        run: |
+          TEMPLATE_FILE='lambda-template.yaml'
+          S3_BUCKET_KEY='new-relic-log-forwarder-folder/new-relic-log-forwarder.zip'
+          
+          sed -i "s|CodeUri: /src|CodeUri:\n    Bucket: !FindInMap [ RegionToS3Bucket, !Ref 'AWS::Region', BucketArn ]\n    Key: '${S3_BUCKET_KEY}'|" "$TEMPLATE_FILE"
+          
+          echo "Template file updated successfully with S3 bucket as CodeUri."
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v3
         with:

--- a/.github/workflows/release-template-files.yaml
+++ b/.github/workflows/release-template-files.yaml
@@ -26,14 +26,22 @@ jobs:
         run: |
           pip install aws-sam-cli
 
-      - name: Prepare Template for S3 Deployment
+      # modify lambda CodeUri to production as s3 bucket destination
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install ruamel
         run: |
-          TEMPLATE_FILE='lambda-template.yaml'
-          S3_BUCKET_KEY='new-relic-log-forwarder-folder/new-relic-log-forwarder.zip'
-          
-          sed -i "s|CodeUri: /src|CodeUri:\n    Bucket: !FindInMap [ RegionToS3Bucket, !Ref 'AWS::Region', BucketArn ]\n    Key: '${S3_BUCKET_KEY}'|" "$TEMPLATE_FILE"
-          
-          echo "Template file updated successfully with S3 bucket as CodeUri."
+          python -m pip install --upgrade pip
+          pip install ruamel.yaml
+
+      - name: Run Python Script to Update lambda-template.yaml
+        run: python workflow-scripts/update_lambda_template.py
+
+      - name: Verify the changes
+        run: cat lambda-template.yaml
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v3

--- a/lambda-template.yaml
+++ b/lambda-template.yaml
@@ -209,9 +209,7 @@ Resources:
     Metadata:
       BuildMethod: go1.x
     Properties:
-      CodeUri:
-        Bucket: !FindInMap [ RegionToS3Bucket, !Ref 'AWS::Region', BucketArn ]
-        Key: 'new-relic-log-forwarder-folder/new-relic-log-forwarder.zip'
+      CodeUri: src/
       Handler: bootstrap
       Runtime: provided.al2023
       Timeout: 900

--- a/workflow-scripts/update_lambda_template.py
+++ b/workflow-scripts/update_lambda_template.py
@@ -1,0 +1,22 @@
+from ruamel.yaml import YAML
+
+yaml = YAML()
+
+file_path = 'lambda-template.yaml'
+
+with open(file_path, 'r') as file:
+    data = yaml.load(file)
+
+resources = data.get('Resources', {})
+nr_log_forwarder = resources.get('NewRelicLogsServerlessLogForwarder', {})
+properties = nr_log_forwarder.get('Properties', {})
+
+properties['CodeUri'] = {
+    'Bucket': yaml.load("!FindInMap [ RegionToS3Bucket, !Ref 'AWS::Region', BucketArn ]"),
+    'Key': "new-relic-log-forwarder-folder/new-relic-log-forwarder.zip"
+}
+
+with open(file_path, 'w') as file:
+    yaml.dump(data, file)
+
+print("Template file updated successfully.")


### PR DESCRIPTION
lambda-template yaml file has s3 bucket names in map hardcoded to fetch lambda code. This blocks developers from testing locally when they upload test files to a different bucket.

Hence modified CodeUri back to /src and modified CI/CD to change the template file with S3 object arn during release stage

**How it looks in local:**
```  
NewRelicLogsServerlessLogForwarder:
    ....
    Properties:
      CodeUri: src/
```

**How it looks after modification and packaging in production:**
```  
NewRelicLogsServerlessLogForwarder:
    ....
    Properties:
      CodeUri:
        Bucket:
          Fn::FindInMap:
          - RegionToS3Bucket
          - Ref: AWS::Region
          - BucketArn
        Key: new-relic-log-forwarder-folder/new-relic-log-forwarder.zip
```

Test pr -> https://github.com/newrelic/aws-unified-lambda/pull/11

Tests run:
1. Validated if lambda-template.yaml CodeUri is changed. Ran e2e tests to validate. 
2. If lambda-template.yaml file doesn't exist then error is thrown in ci/cd and further steps are not run
<img width="1137" alt="Screenshot 2024-12-16 at 12 56 05 PM" src="https://github.com/user-attachments/assets/d7381324-49e9-4297-b4c8-538b0419d57e" />
