### PR TITLE
parsing requestId from message and stamping it as attribute

### DIFF
--- a/src/cloudwatch/cloudwatch.go
+++ b/src/cloudwatch/cloudwatch.go
@@ -57,7 +57,7 @@ func batchLogEntries(cloudwatchLogsData events.CloudwatchLogsData, channel chan 
 	regularExpression := regexp.MustCompile(common.RequestIDRegex)
 
 	// Variable to keep track of the last requestId found
-	var lastRequestId string
+	var lastRequestID string
 
 	for _, record := range cloudwatchLogsData.LogEvents {
 		messages := util.SplitLargeMessages(record.Message)
@@ -68,7 +68,7 @@ func batchLogEntries(cloudwatchLogsData events.CloudwatchLogsData, channel chan 
 				Log:       message,
 			}
 
-			lastRequestId = util.AddRequestId(cloudwatchLogsData.LogGroup, message, attributes, lastRequestId, regularExpression)
+			lastRequestID = util.AddRequestID(cloudwatchLogsData.LogGroup, message, attributes, lastRequestID, regularExpression)
 
 			if batchSize+len(message) > common.MaxPayloadSize || messageCount >= common.MaxPayloadMessages {
 				util.ProduceMessageToChannel(channel, currentBatch, attributes)

--- a/src/cloudwatch/cloudwatch.go
+++ b/src/cloudwatch/cloudwatch.go
@@ -61,14 +61,17 @@ func batchLogEntries(cloudwatchLogsData events.CloudwatchLogsData, channel chan 
 
 	for _, record := range cloudwatchLogsData.LogEvents {
 		messages := util.SplitLargeMessages(record.Message)
-
 		for _, message := range messages {
-			entry := common.Log{
-				Timestamp: strconv.FormatInt(record.Timestamp, 10),
-				Log:       message,
-			}
 
-			lastRequestID = util.AddRequestID(cloudwatchLogsData.LogGroup, message, attributes, lastRequestID, regularExpression)
+			// logAttribute is a map of attributes for each individual log message.
+			logAttribute := common.LogAttributes{}
+
+			entry := common.Log{
+				Timestamp:  strconv.FormatInt(record.Timestamp, 10),
+				Log:        message,
+				Attributes: logAttribute,
+			}
+			lastRequestID = util.AddRequestID(cloudwatchLogsData.LogGroup, message, logAttribute, lastRequestID, regularExpression)
 
 			if batchSize+len(message) > common.MaxPayloadSize || messageCount >= common.MaxPayloadMessages {
 				util.ProduceMessageToChannel(channel, currentBatch, attributes)

--- a/src/cloudwatch/cloudwatch.go
+++ b/src/cloudwatch/cloudwatch.go
@@ -55,7 +55,7 @@ func batchLogEntries(cloudwatchLogsData events.CloudwatchLogsData, channel chan 
 	var currentBatch common.LogData
 
 	// Regular expression to match the pattern "RequestId: <UUID> <message>"
-	regularExpression := regexp.MustCompile(common.RequestIdRegex)
+	regularExpression := regexp.MustCompile(common.RequestIDRegex)
 
 	for _, record := range cloudwatchLogsData.LogEvents {
 		messages := util.SplitLargeMessages(record.Message)

--- a/src/common/constants.go
+++ b/src/common/constants.go
@@ -46,3 +46,9 @@ const CloudTrailDigestRegex = ".*_CloudTrail-Digest_.*\\.json\\.gz$"
 
 // CloudTrailRegex is the regex pattern for CloudTrail files.
 const CloudTrailRegex = ".*_CloudTrail_.*\\.json\\.gz$"
+
+// RequestIdRegex is the regex pattern for RequestId.
+const RequestIdRegex = "RequestId:\\s([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
+
+// Prefix for identifing log group belonging to lambda
+const LambdaLogGroup = "/aws/lambda"

--- a/src/common/constants.go
+++ b/src/common/constants.go
@@ -47,8 +47,8 @@ const CloudTrailDigestRegex = ".*_CloudTrail-Digest_.*\\.json\\.gz$"
 // CloudTrailRegex is the regex pattern for CloudTrail files.
 const CloudTrailRegex = ".*_CloudTrail_.*\\.json\\.gz$"
 
-// RequestIdRegex is the regex pattern for RequestId.
-const RequestIdRegex = "RequestId:\\s([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
+// RequestIDRegex is the regex pattern for RequestId.
+const RequestIDRegex = "RequestId:\\s([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
 
-// Prefix for identifing log group belonging to lambda
+// LambdaLogGroup is prefix for identifing log group belonging to lambda
 const LambdaLogGroup = "/aws/lambda"

--- a/src/util/message_util.go
+++ b/src/util/message_util.go
@@ -104,8 +104,8 @@ func AddRequestID(message string, logAttribute common.LogAttributes, lastRequest
 	var jsonMessage map[string]interface{}
 	if err := json.Unmarshal([]byte(message), &jsonMessage); err == nil {
 		// Message is in JSON format
-		if requestId, ok := ExtractRequestIDFromJSON(jsonMessage); ok {
-			lastRequestID = requestId
+		if requestID, ok := ExtractRequestIDFromJSON(jsonMessage); ok {
+			lastRequestID = requestID
 			logAttribute["requestId"] = lastRequestID
 		} else if lastRequestID != "" {
 			logAttribute["requestId"] = lastRequestID
@@ -128,12 +128,12 @@ func AddRequestID(message string, logAttribute common.LogAttributes, lastRequest
 // It returns the requestId and a boolean indicating if the requestId was found.
 // The function handle both the cases where the requestId is at the top level or inside the record.requestId.
 func ExtractRequestIDFromJSON(jsonMessage map[string]interface{}) (string, bool) {
-	if requestId, ok := jsonMessage["requestId"].(string); ok {
-		return requestId, true
+	if requestID, ok := jsonMessage["requestId"].(string); ok {
+		return requestID, true
 	}
 	if record, ok := jsonMessage["record"].(map[string]interface{}); ok {
-		if requestId, ok := record["requestId"].(string); ok {
-			return requestId, true
+		if requestID, ok := record["requestId"].(string); ok {
+			return requestID, true
 		}
 	}
 	return "", false

--- a/src/util/message_util.go
+++ b/src/util/message_util.go
@@ -97,19 +97,19 @@ func ParseCloudTrailEvents(message string) ([]string, error) {
 	return records, nil
 }
 
-// AddRequestId extracts the requestId from the message and updates the attributes map.
+// AddRequestID extracts the requestId from the message and updates the attributes map.
 // It returns the last requestId found to keep track of the requestId across log messages.
-func AddRequestId(logGroup, message string, attributes common.LogAttributes, lastRequestId string, regularExpression *regexp.Regexp) string {
+func AddRequestID(logGroup, message string, attributes common.LogAttributes, lastRequestID string, regularExpression *regexp.Regexp) string {
 
 	if strings.HasPrefix(logGroup, common.LambdaLogGroup) {
 		matches := regularExpression.FindStringSubmatch(message)
 		if len(matches) == 2 {
-			lastRequestId = matches[1]
-			attributes["requestId"] = lastRequestId
-		} else if lastRequestId != "" {
-			attributes["requestId"] = lastRequestId
+			lastRequestID = matches[1]
+			attributes["requestId"] = lastRequestID
+		} else if lastRequestID != "" {
+			attributes["requestId"] = lastRequestID
 		}
 	}
 
-	return lastRequestId
+	return lastRequestID
 }

--- a/src/util/message_util.go
+++ b/src/util/message_util.go
@@ -113,6 +113,7 @@ func AddRequestID(message string, logAttribute common.LogAttributes, lastRequest
 	} else {
 		// Message is in text format
 		matches := regularExpression.FindStringSubmatch(message)
+		// if message has valid regular expression then matches will have 2 elements, first element is the whole string and second element is the requestId
 		if len(matches) == 2 {
 			lastRequestID = matches[1]
 			logAttribute["requestId"] = lastRequestID

--- a/src/util/message_util.go
+++ b/src/util/message_util.go
@@ -99,17 +99,16 @@ func ParseCloudTrailEvents(message string) ([]string, error) {
 
 // AddRequestID extracts the requestId from the message and updates the attributes map.
 // It returns the last requestId found to keep track of the requestId across log messages.
-func AddRequestID(logGroup, message string, attributes common.LogAttributes, lastRequestID string, regularExpression *regexp.Regexp) string {
+func AddRequestID(logGroup, message string, logAttribute common.LogAttributes, lastRequestID string, regularExpression *regexp.Regexp) string {
 
 	if strings.HasPrefix(logGroup, common.LambdaLogGroup) {
 		matches := regularExpression.FindStringSubmatch(message)
 		if len(matches) == 2 {
 			lastRequestID = matches[1]
-			attributes["requestId"] = lastRequestID
+			logAttribute["requestId"] = lastRequestID
 		} else if lastRequestID != "" {
-			attributes["requestId"] = lastRequestID
+			logAttribute["requestId"] = lastRequestID
 		}
 	}
-
 	return lastRequestID
 }

--- a/src/util/message_util_test.go
+++ b/src/util/message_util_test.go
@@ -218,7 +218,7 @@ func TestAddRequestId(t *testing.T) {
 		name           string
 		logGroup       string
 		message        string
-		attributes     common.LogAttributes
+		logAttribute   common.LogAttributes
 		lastRequestID  string
 		expectedReqID  string
 		expectedAttrib common.LogAttributes
@@ -227,7 +227,7 @@ func TestAddRequestId(t *testing.T) {
 			name:          "Valid RequestId",
 			logGroup:      "/aws/lambda/test",
 			message:       "RequestId: d653fb2c-0234-46ff-ae6b-9a418b888420 hello world",
-			attributes:    common.LogAttributes{},
+			logAttribute:  common.LogAttributes{},
 			lastRequestID: "",
 			expectedReqID: "d653fb2c-0234-46ff-ae6b-9a418b888420",
 			expectedAttrib: common.LogAttributes{
@@ -238,7 +238,7 @@ func TestAddRequestId(t *testing.T) {
 			name:          "No RequestId in message",
 			logGroup:      "/aws/lambda/test",
 			message:       "hello world",
-			attributes:    common.LogAttributes{},
+			logAttribute:  common.LogAttributes{},
 			lastRequestID: "d653fb2c-0234-46ff-ae6b-9a418b888420",
 			expectedReqID: "d653fb2c-0234-46ff-ae6b-9a418b888420",
 			expectedAttrib: common.LogAttributes{
@@ -249,7 +249,7 @@ func TestAddRequestId(t *testing.T) {
 			name:           "No RequestId and no previous RequestId",
 			logGroup:       "/aws/lambda/test",
 			message:        "hello world",
-			attributes:     common.LogAttributes{},
+			logAttribute:   common.LogAttributes{},
 			lastRequestID:  "",
 			expectedReqID:  "",
 			expectedAttrib: common.LogAttributes{},
@@ -258,7 +258,7 @@ func TestAddRequestId(t *testing.T) {
 			name:           "Non-matching log group",
 			logGroup:       "/aws/other/test",
 			message:        "RequestId: d653fb2c-0234-46ff-ae6b-9a418b888420 hello world",
-			attributes:     common.LogAttributes{},
+			logAttribute:   common.LogAttributes{},
 			lastRequestID:  "",
 			expectedReqID:  "",
 			expectedAttrib: common.LogAttributes{},
@@ -270,9 +270,9 @@ func TestAddRequestId(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotReqID := AddRequestID(tt.logGroup, tt.message, tt.attributes, tt.lastRequestID, re)
+			gotReqID := AddRequestID(tt.logGroup, tt.message, tt.logAttribute, tt.lastRequestID, re)
 			assert.Equal(t, tt.expectedReqID, gotReqID)
-			assert.Equal(t, tt.expectedAttrib, tt.attributes)
+			assert.Equal(t, tt.expectedAttrib, tt.logAttribute)
 		})
 	}
 }

--- a/src/util/message_util_test.go
+++ b/src/util/message_util_test.go
@@ -219,8 +219,8 @@ func TestAddRequestId(t *testing.T) {
 		logGroup       string
 		message        string
 		attributes     common.LogAttributes
-		lastRequestId  string
-		expectedReqId  string
+		lastRequestID  string
+		expectedReqID  string
 		expectedAttrib common.LogAttributes
 	}{
 		{
@@ -228,8 +228,8 @@ func TestAddRequestId(t *testing.T) {
 			logGroup:      "/aws/lambda/test",
 			message:       "RequestId: d653fb2c-0234-46ff-ae6b-9a418b888420 hello world",
 			attributes:    common.LogAttributes{},
-			lastRequestId: "",
-			expectedReqId: "d653fb2c-0234-46ff-ae6b-9a418b888420",
+			lastRequestID: "",
+			expectedReqID: "d653fb2c-0234-46ff-ae6b-9a418b888420",
 			expectedAttrib: common.LogAttributes{
 				"requestId": "d653fb2c-0234-46ff-ae6b-9a418b888420",
 			},
@@ -239,8 +239,8 @@ func TestAddRequestId(t *testing.T) {
 			logGroup:      "/aws/lambda/test",
 			message:       "hello world",
 			attributes:    common.LogAttributes{},
-			lastRequestId: "d653fb2c-0234-46ff-ae6b-9a418b888420",
-			expectedReqId: "d653fb2c-0234-46ff-ae6b-9a418b888420",
+			lastRequestID: "d653fb2c-0234-46ff-ae6b-9a418b888420",
+			expectedReqID: "d653fb2c-0234-46ff-ae6b-9a418b888420",
 			expectedAttrib: common.LogAttributes{
 				"requestId": "d653fb2c-0234-46ff-ae6b-9a418b888420",
 			},
@@ -250,8 +250,8 @@ func TestAddRequestId(t *testing.T) {
 			logGroup:       "/aws/lambda/test",
 			message:        "hello world",
 			attributes:     common.LogAttributes{},
-			lastRequestId:  "",
-			expectedReqId:  "",
+			lastRequestID:  "",
+			expectedReqID:  "",
 			expectedAttrib: common.LogAttributes{},
 		},
 		{
@@ -259,8 +259,8 @@ func TestAddRequestId(t *testing.T) {
 			logGroup:       "/aws/other/test",
 			message:        "RequestId: d653fb2c-0234-46ff-ae6b-9a418b888420 hello world",
 			attributes:     common.LogAttributes{},
-			lastRequestId:  "",
-			expectedReqId:  "",
+			lastRequestID:  "",
+			expectedReqID:  "",
 			expectedAttrib: common.LogAttributes{},
 		},
 	}
@@ -270,8 +270,8 @@ func TestAddRequestId(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotReqId := AddRequestId(tt.logGroup, tt.message, tt.attributes, tt.lastRequestId, re)
-			assert.Equal(t, tt.expectedReqId, gotReqId)
+			gotReqID := AddRequestID(tt.logGroup, tt.message, tt.attributes, tt.lastRequestID, re)
+			assert.Equal(t, tt.expectedReqID, gotReqID)
 			assert.Equal(t, tt.expectedAttrib, tt.attributes)
 		})
 	}

--- a/src/util/message_util_test.go
+++ b/src/util/message_util_test.go
@@ -223,6 +223,18 @@ func TestAddRequestId(t *testing.T) {
 		expectedAttrib common.LogAttributes
 	}{
 		{
+			name: "Case where RequestId is already present",
+			messages: []string{
+				"second message",
+			},
+			logAttribute:  common.LogAttributes{},
+			lastRequestID: "d653fb2c-0234-46ff-ae6b-9a418b888420",
+			expectedReqID: "d653fb2c-0234-46ff-ae6b-9a418b888420",
+			expectedAttrib: common.LogAttributes{
+				"requestId": "d653fb2c-0234-46ff-ae6b-9a418b888420",
+			},
+		},
+		{
 			name: "Valid RequestId in text message",
 			messages: []string{
 				"RequestId: d653fb2c-0234-46ff-ae6b-9a418b888420 hello world",
@@ -314,6 +326,24 @@ func TestAddRequestId(t *testing.T) {
 			},
 			logAttribute:  common.LogAttributes{},
 			lastRequestID: "",
+			expectedReqID: "4e3e651f-f7a7-46c4-acec-a07ca9876ba6",
+			expectedAttrib: common.LogAttributes{
+				"requestId": "4e3e651f-f7a7-46c4-acec-a07ca9876ba6",
+			},
+		},
+		{
+			name: "Testing scenario with requestId already present for JSON message",
+			messages: []string{
+				`{
+                    "time": "2025-01-15T02:10:15.287Z",
+                    "type": "platform.start",
+                    "record": {
+                        "version": "$LATEST"
+                    }
+                }`,
+			},
+			logAttribute:  common.LogAttributes{},
+			lastRequestID: "4e3e651f-f7a7-46c4-acec-a07ca9876ba6",
 			expectedReqID: "4e3e651f-f7a7-46c4-acec-a07ca9876ba6",
 			expectedAttrib: common.LogAttributes{
 				"requestId": "4e3e651f-f7a7-46c4-acec-a07ca9876ba6",


### PR DESCRIPTION
**This PR is for supporting the existing requestId feature from our previous implementation where we were parsing each message and if the message has "RequestId: UUID", we are parsing it and adding it as an attribute.**

In our earlier implementation this attribute was named **aws.lambda_request_id**, but in this implementation we will be using the attribute name as **requestId**. This is done to make it similar to the key name which aws is sending when the log type is of json. 

**This change is applicable to log message which are of type text and JSON as well. ** 

Testing Done:
1. Positive case: Send a valid message "START RequestId: d653fb2c-0234-46ff-ae6b-9a418b888420 Version: $LATEST INFO ERROR hrai", the message will flow to new relic and an attribute named requestId with value d653fb2c-0234-46ff-ae6b-9a418b888420 is attached to the logs in new relic. 

2. Positive case: Send a valid message with 2 UUID "START RequestId: d653fb2c-0234-46ff-ae6b-9a418b888420 Version: $LATEST START RequestId: d653fb2c-0234-46ff-ae6b-9a418b888422 Version: $LATEST hrai INFO ERROR", the message will flow to new relic and an attribute named requestId with value d653fb2c-0234-46ff-ae6b-9a418b888420 (first occurence of UUID)is attached to the logs in new relic.  (This is just a test case and we won't get two UUID in same message.)

3. Send a json: 
{
    "time": "2024-12-12T11:40:11Z",
    "level": "INFO",
    "message": "hrai hello",
    "logger": "root",
    "requestId": "6bff3185-1cee-4c13-addb-0c038a197abc"
}
here also the attribute named requestId with value **6bff3185-1cee-4c13-addb-0c038a197abc** will be attached to the logs.   ( This was working earlier as well, no changes, just testing regression)

4. Send a complex JSON:
{
    "time": "2024-12-12T11:40:11.054Z",
    "type": "platform.report ERROR",
    "record": {
        "requestId": "6bff3185-1cee-4c13-addb-0c038a197abc",
        "metrics": {
            "durationMs": 9.335,
            "billedDurationMs": 10,
            "memorySizeMB": 128,
            "maxMemoryUsedMB": 30,
            "initDurationMs": 92.552
        },
        "status": "success",
        "level": "INFO"
    }
}

Here the attribute named record.requestId with value **6bff3185-1cee-4c13-addb-0c038a197abc** will be attached to the logs as well as a new attribute requestId will be attached with value **6bff3185-1cee-4c13-addb-0c038a197abc**

5. Negative test case: Send messge: "START RequestId:d653fb-0234-46ff-ae6b-9a418b888420 Version: $LATEST INFO ERROR hrai", since it won't match our regex we won't attach any attribute to the logs.

6. Negative test case: Send messge: "START RequestId: d653fb-0234-46ff-ae6b-9a418b888420 Version: $LATEST INFO ERROR hrai", since it won't match our regex we won't attach any attribute to the logs. (The UUID is not valid UUID)

