### PR TITLE
version changes

### DIFF
--- a/src/common/constants.go
+++ b/src/common/constants.go
@@ -7,9 +7,6 @@ const InstrumentationProvider = "aws"
 // InstrumentationName is a parameter necessary for Entity Synthesis at New Relic.
 const InstrumentationName = "lambda"
 
-// InstrumentationVersion is a parameter necessary for Entity Synthesis at New Relic.
-const InstrumentationVersion = "1.0.0"
-
 // CustomMetaData is the name of the environment variable for custom meta data.
 const CustomMetaData = "CUSTOM_META_DATA"
 

--- a/src/common/version.go
+++ b/src/common/version.go
@@ -1,0 +1,5 @@
+// Package common provides common constants structs and variables.
+package common
+
+// InstrumentationVersion is a parameter necessary for Entity Synthesis at New Relic.
+const InstrumentationVersion = "1.1.0"


### PR DESCRIPTION
This PR will bump up the version of instrumentation.provider to 1.1.0 which we now are reading from a different file version.go