### PR TITLE
updated entity_synthesis_param.cfg file with version change and new line

### DIFF
--- a/e2e-tests/common-scripts/entity_synthesis_param.cfg
+++ b/e2e-tests/common-scripts/entity_synthesis_param.cfg
@@ -1,4 +1,4 @@
 # Entity synthesis Parameters , aws related params are dropped in pipeline.
 instrumentation_provider=aws
 instrumentation_name=lambda
-instrumentation_version=1.0.0
+instrumentation_version=1.1.0


### PR DESCRIPTION
entity synthesis was failing in e2e tests because the last parameter in the config file was not read due to missing /n. Added version change and new line to e2e tests