### PR TITLE
[NR-439586] Fix E2E tests

### DIFF
--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -240,6 +240,8 @@ jobs:
           cd e2e-tests/
           ./lambda-with-metrics-test.sh test_for_lambda_metrics_polling_stack
           ./lambda-with-metrics-test.sh test_for_lambda_metrics_streaming_stack
+          ./lambda-with-metrics-test.sh test_for_firehose_metric_polling_stack
+          ./lambda-with-metrics-test.sh test_for_firehose_metric_streaming_stack
           ./lambda-with-metrics-test.sh test_for_lambda_firehose_metric_polling_stack
           ./lambda-with-metrics-test.sh test_for_lambda_firehose_metric_streaming_stack
 

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -249,35 +249,35 @@ jobs:
 #          notify_when: 'failure'
 #        env:
 #          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-  clean-up:
-    needs: [run-e2e-tests-cloudwatch, run-e2e-tests-s3, run-e2e-tests-lambda-firehose, run-e2e-tests-lambda-firehose-metrics]
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: write
-    steps:
-      - name: Install AWS SAM CLI
-        run: |
-          pip install aws-sam-cli
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v3
-        with:
-          role-to-assume: ${{ secrets.AWS_E2E_ROLE }}
-          aws-region: us-east-1
-
-      - name: Delete Resources
-        env:
-          S3_BUCKET: unified-lambda-e2e-test-templates
-        run:
-          aws s3 rm "s3://$S3_BUCKET" --recursive
-
-      - name: Send failure notification to Slack
-        if: always()
-        uses: ravsamhq/notify-slack-action@v1
-        with:
-          status: ${{ job.status }}
-          notify_when: 'failure'
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+#
+#  clean-up:
+#    needs: [run-e2e-tests-cloudwatch, run-e2e-tests-s3, run-e2e-tests-lambda-firehose, run-e2e-tests-lambda-firehose-metrics]
+#    runs-on: ubuntu-latest
+#    permissions:
+#      id-token: write
+#      contents: write
+#    steps:
+#      - name: Install AWS SAM CLI
+#        run: |
+#          pip install aws-sam-cli
+#
+#      - name: Configure AWS Credentials
+#        uses: aws-actions/configure-aws-credentials@v3
+#        with:
+#          role-to-assume: ${{ secrets.AWS_E2E_ROLE }}
+#          aws-region: us-east-1
+#
+#      - name: Delete Resources
+#        env:
+#          S3_BUCKET: unified-lambda-e2e-test-templates
+#        run:
+#          aws s3 rm "s3://$S3_BUCKET" --recursive
+#
+#      - name: Send failure notification to Slack
+#        if: always()
+#        uses: ravsamhq/notify-slack-action@v1
+#        with:
+#          status: ${{ job.status }}
+#          notify_when: 'failure'
+#        env:
+#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -1,15 +1,12 @@
 name: E2E Test Workflow
 
 on:
-  pull_request_review:
-    types:
-      - submitted
-  schedule:
-    - cron: '0 0 1 * *'
+  pull_request:
+    branches:
+      - develop
 
 jobs:
   build-templates:
-    if: github.event.review.state == 'approved'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -158,15 +155,12 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-  run-e2e-tests-lambda-firehose-metrics:
+  run-e2e-tests-lambda-firehose:
     needs: [build-templates]
     runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: write
-    strategy:
-      matrix:
-        test-case: [test_for_lambda_firehose_stack, test_for_firehose_metric_polling_stack, test_for_firehose_metric_streaming_stack, test_for_lambda_metrics_polling_stack, test_for_lambda_metrics_streaming_stack, test_for_lambda_firehose_metric_polling_stack, test_for_lambda_firehose_metric_streaming_stack]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -197,7 +191,7 @@ jobs:
           NEW_RELIC_LICENSE_KEY: ${{ secrets.NEW_RELIC_LICENSE_KEY }}
         run: |
           cd e2e-tests/
-          ./lambda-with-metrics-test.sh ${{ matrix.test-case }}
+          ./lambda-with-metrics-test.sh test_for_lambda_firehose_stack
 
       - name: Send failure notification to Slack
         if: always()
@@ -208,8 +202,56 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
+  run-e2e-tests-lambda-firehose-metrics:
+    needs: [build-templates]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download Artifact
+        uses: actions/download-artifact@v4
+        with:
+          path: build-artifacts
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+
+      - name: Install AWS SAM CLI
+        run: |
+          pip install aws-sam-cli
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          role-to-assume: ${{ secrets.AWS_E2E_ROLE }}
+          aws-region: us-east-1
+
+      - name: Run e2e tests for lambda and metrics stack
+        env:
+          NEW_RELIC_USER_KEY: ${{ secrets.NEW_RELIC_USER_KEY }}
+          NEW_RELIC_LICENSE_KEY: ${{ secrets.NEW_RELIC_LICENSE_KEY }}
+        run: |
+          cd e2e-tests/
+          ./lambda-with-metrics-test.sh test_for_firehose_metric_polling_stack
+          ./lambda-with-metrics-test.sh test_for_firehose_metric_streaming_stack
+
+#      - name: Send failure notification to Slack
+#        if: always()
+#        uses: ravsamhq/notify-slack-action@v1
+#        with:
+#          status: ${{ job.status }}
+#          notify_when: 'failure'
+#        env:
+#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
   clean-up:
-    needs: [run-e2e-tests-cloudwatch, run-e2e-tests-s3, run-e2e-tests-lambda-firehose-metrics]
+    needs: [run-e2e-tests-cloudwatch, run-e2e-tests-s3, run-e2e-tests-lambda-firehose, run-e2e-tests-lambda-firehose-metrics]
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -13,7 +13,7 @@ jobs:
       contents: write
     strategy:
       matrix:
-        TEMPLATE_FILE: [lambda-template, logging-lambda-firehose-template, logging-lambda-metric-polling, logging-lambda-metric-stream, logging-firehose-metric-polling, logging-firehose-metric-stream, logging-lambda-firehose-metric-polling, logging-lambda-firehose-metric-stream]
+        TEMPLATE_FILE: [logging-firehose-metric-polling, logging-firehose-metric-stream]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -55,152 +55,152 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-  run-e2e-tests-cloudwatch:
-    needs: [build-templates]
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: write
-    strategy:
-      matrix:
-        test-case: [test_logs_with_filter_pattern, test_logs_for_secret_manager, test_logs_for_invalid_log_group]
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Download Artifact
-        uses: actions/download-artifact@v4
-        with:
-          path: build-artifacts
-
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.22'
-
-      - name: Install AWS SAM CLI
-        run: |
-          pip install aws-sam-cli
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v3
-        with:
-          role-to-assume: ${{ secrets.AWS_E2E_ROLE }}
-          aws-region: us-east-1
-
-      - name: Run e2e tests for cloudwatch
-        env:
-          NEW_RELIC_USER_KEY: ${{ secrets.NEW_RELIC_USER_KEY }}
-          NEW_RELIC_LICENSE_KEY: ${{ secrets.NEW_RELIC_LICENSE_KEY }}
-        run: |
-          cd e2e-tests
-          ./lambda-cloudwatch-trigger.sh ${{ matrix.test-case }}
-
-      - name: Send failure notification to Slack
-        if: always()
-        uses: ravsamhq/notify-slack-action@v1
-        with:
-          status: ${{ job.status }}
-          notify_when: 'failure'
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-  run-e2e-tests-s3:
-    needs: [build-templates]
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: write
-    strategy:
-      matrix:
-        test-case: [test_logs_for_prefix, test_logs_for_secret_manager, test_logs_for_invalid_bucket_name]
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Download Artifact
-        uses: actions/download-artifact@v4
-        with:
-          path: build-artifacts
-
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.22'
-
-      - name: Install AWS SAM CLI
-        run: |
-          pip install aws-sam-cli
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v3
-        with:
-          role-to-assume: ${{ secrets.AWS_E2E_ROLE }}
-          aws-region: us-east-1
-
-      - name: Run e2e tests for s3
-        env:
-          NEW_RELIC_USER_KEY: ${{ secrets.NEW_RELIC_USER_KEY }}
-          NEW_RELIC_LICENSE_KEY: ${{ secrets.NEW_RELIC_LICENSE_KEY }}
-        run: |
-          cd e2e-tests
-          ./lambda-s3-trigger.sh ${{ matrix.test-case }}
-
-      - name: Send failure notification to Slack
-        if: always()
-        uses: ravsamhq/notify-slack-action@v1
-        with:
-          status: ${{ job.status }}
-          notify_when: 'failure'
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-  run-e2e-tests-lambda-firehose:
-    needs: [build-templates]
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Download Artifact
-        uses: actions/download-artifact@v4
-        with:
-          path: build-artifacts
-
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.22'
-
-      - name: Install AWS SAM CLI
-        run: |
-          pip install aws-sam-cli
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v3
-        with:
-          role-to-assume: ${{ secrets.AWS_E2E_ROLE }}
-          aws-region: us-east-1
-
-      - name: Run e2e tests for lambda and metrics stack
-        env:
-          NEW_RELIC_USER_KEY: ${{ secrets.NEW_RELIC_USER_KEY }}
-          NEW_RELIC_LICENSE_KEY: ${{ secrets.NEW_RELIC_LICENSE_KEY }}
-        run: |
-          cd e2e-tests/
-          ./lambda-with-metrics-test.sh test_for_lambda_firehose_stack
-
-      - name: Send failure notification to Slack
-        if: always()
-        uses: ravsamhq/notify-slack-action@v1
-        with:
-          status: ${{ job.status }}
-          notify_when: 'failure'
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+#  run-e2e-tests-cloudwatch:
+#    needs: [build-templates]
+#    runs-on: ubuntu-latest
+#    permissions:
+#      id-token: write
+#      contents: write
+#    strategy:
+#      matrix:
+#        test-case: [test_logs_with_filter_pattern, test_logs_for_secret_manager, test_logs_for_invalid_log_group]
+#    steps:
+#      - name: Checkout code
+#        uses: actions/checkout@v4
+#
+#      - name: Download Artifact
+#        uses: actions/download-artifact@v4
+#        with:
+#          path: build-artifacts
+#
+#      - name: Setup Go
+#        uses: actions/setup-go@v5
+#        with:
+#          go-version: '1.22'
+#
+#      - name: Install AWS SAM CLI
+#        run: |
+#          pip install aws-sam-cli
+#
+#      - name: Configure AWS Credentials
+#        uses: aws-actions/configure-aws-credentials@v3
+#        with:
+#          role-to-assume: ${{ secrets.AWS_E2E_ROLE }}
+#          aws-region: us-east-1
+#
+#      - name: Run e2e tests for cloudwatch
+#        env:
+#          NEW_RELIC_USER_KEY: ${{ secrets.NEW_RELIC_USER_KEY }}
+#          NEW_RELIC_LICENSE_KEY: ${{ secrets.NEW_RELIC_LICENSE_KEY }}
+#        run: |
+#          cd e2e-tests
+#          ./lambda-cloudwatch-trigger.sh ${{ matrix.test-case }}
+#
+#      - name: Send failure notification to Slack
+#        if: always()
+#        uses: ravsamhq/notify-slack-action@v1
+#        with:
+#          status: ${{ job.status }}
+#          notify_when: 'failure'
+#        env:
+#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+#
+#  run-e2e-tests-s3:
+#    needs: [build-templates]
+#    runs-on: ubuntu-latest
+#    permissions:
+#      id-token: write
+#      contents: write
+#    strategy:
+#      matrix:
+#        test-case: [test_logs_for_prefix, test_logs_for_secret_manager, test_logs_for_invalid_bucket_name]
+#    steps:
+#      - name: Checkout code
+#        uses: actions/checkout@v4
+#
+#      - name: Download Artifact
+#        uses: actions/download-artifact@v4
+#        with:
+#          path: build-artifacts
+#
+#      - name: Setup Go
+#        uses: actions/setup-go@v5
+#        with:
+#          go-version: '1.22'
+#
+#      - name: Install AWS SAM CLI
+#        run: |
+#          pip install aws-sam-cli
+#
+#      - name: Configure AWS Credentials
+#        uses: aws-actions/configure-aws-credentials@v3
+#        with:
+#          role-to-assume: ${{ secrets.AWS_E2E_ROLE }}
+#          aws-region: us-east-1
+#
+#      - name: Run e2e tests for s3
+#        env:
+#          NEW_RELIC_USER_KEY: ${{ secrets.NEW_RELIC_USER_KEY }}
+#          NEW_RELIC_LICENSE_KEY: ${{ secrets.NEW_RELIC_LICENSE_KEY }}
+#        run: |
+#          cd e2e-tests
+#          ./lambda-s3-trigger.sh ${{ matrix.test-case }}
+#
+#      - name: Send failure notification to Slack
+#        if: always()
+#        uses: ravsamhq/notify-slack-action@v1
+#        with:
+#          status: ${{ job.status }}
+#          notify_when: 'failure'
+#        env:
+#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+#
+#  run-e2e-tests-lambda-firehose:
+#    needs: [build-templates]
+#    runs-on: ubuntu-latest
+#    permissions:
+#      id-token: write
+#      contents: write
+#    steps:
+#      - name: Checkout code
+#        uses: actions/checkout@v4
+#
+#      - name: Download Artifact
+#        uses: actions/download-artifact@v4
+#        with:
+#          path: build-artifacts
+#
+#      - name: Setup Go
+#        uses: actions/setup-go@v5
+#        with:
+#          go-version: '1.22'
+#
+#      - name: Install AWS SAM CLI
+#        run: |
+#          pip install aws-sam-cli
+#
+#      - name: Configure AWS Credentials
+#        uses: aws-actions/configure-aws-credentials@v3
+#        with:
+#          role-to-assume: ${{ secrets.AWS_E2E_ROLE }}
+#          aws-region: us-east-1
+#
+#      - name: Run e2e tests for lambda and metrics stack
+#        env:
+#          NEW_RELIC_USER_KEY: ${{ secrets.NEW_RELIC_USER_KEY }}
+#          NEW_RELIC_LICENSE_KEY: ${{ secrets.NEW_RELIC_LICENSE_KEY }}
+#        run: |
+#          cd e2e-tests/
+#          ./lambda-with-metrics-test.sh test_for_lambda_firehose_stack
+#
+#      - name: Send failure notification to Slack
+#        if: always()
+#        uses: ravsamhq/notify-slack-action@v1
+#        with:
+#          status: ${{ job.status }}
+#          notify_when: 'failure'
+#        env:
+#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   run-e2e-tests-lambda-firehose-metrics:
     needs: [build-templates]

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -1,12 +1,15 @@
 name: E2E Test Workflow
 
 on:
-  pull_request:
-    branches:
-      - develop
+  pull_request_review:
+    types:
+      - submitted
+  schedule:
+    - cron: '0 0 1 * *'
 
 jobs:
   build-templates:
+    if: github.event.review.state == 'approved'
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -13,7 +13,7 @@ jobs:
       contents: write
     strategy:
       matrix:
-        TEMPLATE_FILE: [logging-firehose-metric-polling, logging-firehose-metric-stream]
+        TEMPLATE_FILE: [lambda-template, logging-lambda-firehose-template, logging-lambda-metric-polling, logging-lambda-metric-stream, logging-firehose-metric-polling, logging-firehose-metric-stream, logging-lambda-firehose-metric-polling, logging-lambda-firehose-metric-stream]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -238,8 +238,10 @@ jobs:
           NEW_RELIC_LICENSE_KEY: ${{ secrets.NEW_RELIC_LICENSE_KEY }}
         run: |
           cd e2e-tests/
-          ./lambda-with-metrics-test.sh test_for_firehose_metric_polling_stack
-          ./lambda-with-metrics-test.sh test_for_firehose_metric_streaming_stack
+          ./lambda-with-metrics-test.sh test_for_lambda_metrics_polling_stack
+          ./lambda-with-metrics-test.sh test_for_lambda_metrics_streaming_stack
+          ./lambda-with-metrics-test.sh test_for_lambda_firehose_metric_polling_stack
+          ./lambda-with-metrics-test.sh test_for_lambda_firehose_metric_streaming_stack
 
 #      - name: Send failure notification to Slack
 #        if: always()

--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -55,152 +55,152 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-#  run-e2e-tests-cloudwatch:
-#    needs: [build-templates]
-#    runs-on: ubuntu-latest
-#    permissions:
-#      id-token: write
-#      contents: write
-#    strategy:
-#      matrix:
-#        test-case: [test_logs_with_filter_pattern, test_logs_for_secret_manager, test_logs_for_invalid_log_group]
-#    steps:
-#      - name: Checkout code
-#        uses: actions/checkout@v4
-#
-#      - name: Download Artifact
-#        uses: actions/download-artifact@v4
-#        with:
-#          path: build-artifacts
-#
-#      - name: Setup Go
-#        uses: actions/setup-go@v5
-#        with:
-#          go-version: '1.22'
-#
-#      - name: Install AWS SAM CLI
-#        run: |
-#          pip install aws-sam-cli
-#
-#      - name: Configure AWS Credentials
-#        uses: aws-actions/configure-aws-credentials@v3
-#        with:
-#          role-to-assume: ${{ secrets.AWS_E2E_ROLE }}
-#          aws-region: us-east-1
-#
-#      - name: Run e2e tests for cloudwatch
-#        env:
-#          NEW_RELIC_USER_KEY: ${{ secrets.NEW_RELIC_USER_KEY }}
-#          NEW_RELIC_LICENSE_KEY: ${{ secrets.NEW_RELIC_LICENSE_KEY }}
-#        run: |
-#          cd e2e-tests
-#          ./lambda-cloudwatch-trigger.sh ${{ matrix.test-case }}
-#
-#      - name: Send failure notification to Slack
-#        if: always()
-#        uses: ravsamhq/notify-slack-action@v1
-#        with:
-#          status: ${{ job.status }}
-#          notify_when: 'failure'
-#        env:
-#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-#
-#  run-e2e-tests-s3:
-#    needs: [build-templates]
-#    runs-on: ubuntu-latest
-#    permissions:
-#      id-token: write
-#      contents: write
-#    strategy:
-#      matrix:
-#        test-case: [test_logs_for_prefix, test_logs_for_secret_manager, test_logs_for_invalid_bucket_name]
-#    steps:
-#      - name: Checkout code
-#        uses: actions/checkout@v4
-#
-#      - name: Download Artifact
-#        uses: actions/download-artifact@v4
-#        with:
-#          path: build-artifacts
-#
-#      - name: Setup Go
-#        uses: actions/setup-go@v5
-#        with:
-#          go-version: '1.22'
-#
-#      - name: Install AWS SAM CLI
-#        run: |
-#          pip install aws-sam-cli
-#
-#      - name: Configure AWS Credentials
-#        uses: aws-actions/configure-aws-credentials@v3
-#        with:
-#          role-to-assume: ${{ secrets.AWS_E2E_ROLE }}
-#          aws-region: us-east-1
-#
-#      - name: Run e2e tests for s3
-#        env:
-#          NEW_RELIC_USER_KEY: ${{ secrets.NEW_RELIC_USER_KEY }}
-#          NEW_RELIC_LICENSE_KEY: ${{ secrets.NEW_RELIC_LICENSE_KEY }}
-#        run: |
-#          cd e2e-tests
-#          ./lambda-s3-trigger.sh ${{ matrix.test-case }}
-#
-#      - name: Send failure notification to Slack
-#        if: always()
-#        uses: ravsamhq/notify-slack-action@v1
-#        with:
-#          status: ${{ job.status }}
-#          notify_when: 'failure'
-#        env:
-#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-#
-#  run-e2e-tests-lambda-firehose:
-#    needs: [build-templates]
-#    runs-on: ubuntu-latest
-#    permissions:
-#      id-token: write
-#      contents: write
-#    steps:
-#      - name: Checkout code
-#        uses: actions/checkout@v4
-#
-#      - name: Download Artifact
-#        uses: actions/download-artifact@v4
-#        with:
-#          path: build-artifacts
-#
-#      - name: Setup Go
-#        uses: actions/setup-go@v5
-#        with:
-#          go-version: '1.22'
-#
-#      - name: Install AWS SAM CLI
-#        run: |
-#          pip install aws-sam-cli
-#
-#      - name: Configure AWS Credentials
-#        uses: aws-actions/configure-aws-credentials@v3
-#        with:
-#          role-to-assume: ${{ secrets.AWS_E2E_ROLE }}
-#          aws-region: us-east-1
-#
-#      - name: Run e2e tests for lambda and metrics stack
-#        env:
-#          NEW_RELIC_USER_KEY: ${{ secrets.NEW_RELIC_USER_KEY }}
-#          NEW_RELIC_LICENSE_KEY: ${{ secrets.NEW_RELIC_LICENSE_KEY }}
-#        run: |
-#          cd e2e-tests/
-#          ./lambda-with-metrics-test.sh test_for_lambda_firehose_stack
-#
-#      - name: Send failure notification to Slack
-#        if: always()
-#        uses: ravsamhq/notify-slack-action@v1
-#        with:
-#          status: ${{ job.status }}
-#          notify_when: 'failure'
-#        env:
-#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  run-e2e-tests-cloudwatch:
+    needs: [build-templates]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+    strategy:
+      matrix:
+        test-case: [test_logs_with_filter_pattern, test_logs_for_secret_manager, test_logs_for_invalid_log_group]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download Artifact
+        uses: actions/download-artifact@v4
+        with:
+          path: build-artifacts
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+
+      - name: Install AWS SAM CLI
+        run: |
+          pip install aws-sam-cli
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          role-to-assume: ${{ secrets.AWS_E2E_ROLE }}
+          aws-region: us-east-1
+
+      - name: Run e2e tests for cloudwatch
+        env:
+          NEW_RELIC_USER_KEY: ${{ secrets.NEW_RELIC_USER_KEY }}
+          NEW_RELIC_LICENSE_KEY: ${{ secrets.NEW_RELIC_LICENSE_KEY }}
+        run: |
+          cd e2e-tests
+          ./lambda-cloudwatch-trigger.sh ${{ matrix.test-case }}
+
+      - name: Send failure notification to Slack
+        if: always()
+        uses: ravsamhq/notify-slack-action@v1
+        with:
+          status: ${{ job.status }}
+          notify_when: 'failure'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  run-e2e-tests-s3:
+    needs: [build-templates]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+    strategy:
+      matrix:
+        test-case: [test_logs_for_prefix, test_logs_for_secret_manager, test_logs_for_invalid_bucket_name]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download Artifact
+        uses: actions/download-artifact@v4
+        with:
+          path: build-artifacts
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+
+      - name: Install AWS SAM CLI
+        run: |
+          pip install aws-sam-cli
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          role-to-assume: ${{ secrets.AWS_E2E_ROLE }}
+          aws-region: us-east-1
+
+      - name: Run e2e tests for s3
+        env:
+          NEW_RELIC_USER_KEY: ${{ secrets.NEW_RELIC_USER_KEY }}
+          NEW_RELIC_LICENSE_KEY: ${{ secrets.NEW_RELIC_LICENSE_KEY }}
+        run: |
+          cd e2e-tests
+          ./lambda-s3-trigger.sh ${{ matrix.test-case }}
+
+      - name: Send failure notification to Slack
+        if: always()
+        uses: ravsamhq/notify-slack-action@v1
+        with:
+          status: ${{ job.status }}
+          notify_when: 'failure'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  run-e2e-tests-lambda-firehose:
+    needs: [build-templates]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download Artifact
+        uses: actions/download-artifact@v4
+        with:
+          path: build-artifacts
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+
+      - name: Install AWS SAM CLI
+        run: |
+          pip install aws-sam-cli
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          role-to-assume: ${{ secrets.AWS_E2E_ROLE }}
+          aws-region: us-east-1
+
+      - name: Run e2e tests for lambda and firehose stack
+        env:
+          NEW_RELIC_USER_KEY: ${{ secrets.NEW_RELIC_USER_KEY }}
+          NEW_RELIC_LICENSE_KEY: ${{ secrets.NEW_RELIC_LICENSE_KEY }}
+        run: |
+          cd e2e-tests/
+          ./lambda-with-metrics-test.sh test_for_lambda_firehose_stack
+
+      - name: Send failure notification to Slack
+        if: always()
+        uses: ravsamhq/notify-slack-action@v1
+        with:
+          status: ${{ job.status }}
+          notify_when: 'failure'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   run-e2e-tests-lambda-firehose-metrics:
     needs: [build-templates]
@@ -232,7 +232,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_E2E_ROLE }}
           aws-region: us-east-1
 
-      - name: Run e2e tests for lambda and metrics stack
+      - name: Run e2e tests for lambda, firehose and metrics stacks
         env:
           NEW_RELIC_USER_KEY: ${{ secrets.NEW_RELIC_USER_KEY }}
           NEW_RELIC_LICENSE_KEY: ${{ secrets.NEW_RELIC_LICENSE_KEY }}
@@ -243,43 +243,43 @@ jobs:
           ./lambda-with-metrics-test.sh test_for_lambda_firehose_metric_polling_stack
           ./lambda-with-metrics-test.sh test_for_lambda_firehose_metric_streaming_stack
 
-#      - name: Send failure notification to Slack
-#        if: always()
-#        uses: ravsamhq/notify-slack-action@v1
-#        with:
-#          status: ${{ job.status }}
-#          notify_when: 'failure'
-#        env:
-#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-#
-#  clean-up:
-#    needs: [run-e2e-tests-cloudwatch, run-e2e-tests-s3, run-e2e-tests-lambda-firehose, run-e2e-tests-lambda-firehose-metrics]
-#    runs-on: ubuntu-latest
-#    permissions:
-#      id-token: write
-#      contents: write
-#    steps:
-#      - name: Install AWS SAM CLI
-#        run: |
-#          pip install aws-sam-cli
-#
-#      - name: Configure AWS Credentials
-#        uses: aws-actions/configure-aws-credentials@v3
-#        with:
-#          role-to-assume: ${{ secrets.AWS_E2E_ROLE }}
-#          aws-region: us-east-1
-#
-#      - name: Delete Resources
-#        env:
-#          S3_BUCKET: unified-lambda-e2e-test-templates
-#        run:
-#          aws s3 rm "s3://$S3_BUCKET" --recursive
-#
-#      - name: Send failure notification to Slack
-#        if: always()
-#        uses: ravsamhq/notify-slack-action@v1
-#        with:
-#          status: ${{ job.status }}
-#          notify_when: 'failure'
-#        env:
-#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - name: Send failure notification to Slack
+        if: always()
+        uses: ravsamhq/notify-slack-action@v1
+        with:
+          status: ${{ job.status }}
+          notify_when: 'failure'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+  clean-up:
+    needs: [run-e2e-tests-cloudwatch, run-e2e-tests-s3, run-e2e-tests-lambda-firehose, run-e2e-tests-lambda-firehose-metrics]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - name: Install AWS SAM CLI
+        run: |
+          pip install aws-sam-cli
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          role-to-assume: ${{ secrets.AWS_E2E_ROLE }}
+          aws-region: us-east-1
+
+      - name: Delete Resources
+        env:
+          S3_BUCKET: unified-lambda-e2e-test-templates
+        run:
+          aws s3 rm "s3://$S3_BUCKET" --recursive
+
+      - name: Send failure notification to Slack
+        if: always()
+        uses: ravsamhq/notify-slack-action@v1
+        with:
+          status: ${{ job.status }}
+          notify_when: 'failure'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
1. E2E tests in aws-unified-lambda is failing because of changes in metrics stack. A resource has been added with fixed name, DeletCFNLambda. Hence only one metrics stack can be installed at a time. 
2. Fix tests, so they run sequentially, not in parallel. 