### PR TITLE
feat(region): add Japan (JP) region support

### DIFF
--- a/lambda-template.yaml
+++ b/lambda-template.yaml
@@ -41,11 +41,12 @@ Parameters:
     ConstraintDescription: "The parameter value cannot be empty, contain spaces, and must be alphanumeric and can contain symbols."
   NewRelicRegion:
     Type: String
-    Description: Datacenter where the data will be sent (US/EU), DO NOT TOUCH
+    Description: Datacenter where the data will be sent (US/EU/JP), DO NOT TOUCH
     Default: "US"
     AllowedValues:
       - "US"
       - "EU"
+      - "JP"
   NewRelicAccountId: 
     Type: String
     Description: Id of the account in New relic

--- a/logging-firehose-metric-polling.yaml
+++ b/logging-firehose-metric-polling.yaml
@@ -108,6 +108,7 @@ Parameters:
     AllowedValues:
       - "US"
       - "EU"
+      - "JP"
   LogGroupConfig:
     Description: "JSON array of objects representing your LogGroup and Filters (if applicable). For example: [{\"LogGroupName\":\"logGroup1\",\"FilterPattern\":\"filter1\"}]"
     Type: String

--- a/logging-firehose-metric-stream.yaml
+++ b/logging-firehose-metric-stream.yaml
@@ -170,6 +170,7 @@ Parameters:
     AllowedValues:
       - "US"
       - "EU"
+      - "JP"
   LogGroupConfig:
     Description: "JSON array of objects representing your LogGroup and Filters (if applicable). For example: [{\"LogGroupName\":\"logGroup1\",\"FilterPattern\":\"filter1\"}]"
     Type: String

--- a/logging-lambda-firehose-metric-polling.yaml
+++ b/logging-lambda-firehose-metric-polling.yaml
@@ -82,8 +82,8 @@ Parameters:
     ConstraintDescription: must only contain numbers
   NewRelicRegion:
     Type: String
-    Description: Datacenter where the data will be sent (US/EU), DO NOT TOUCH
-    AllowedValues: [US, EU]
+    Description: Datacenter where the data will be sent (US/EU/JP), DO NOT TOUCH
+    AllowedValues: [US, EU, JP]
     Default: US
   IntegrationName:
     Type: String

--- a/logging-lambda-firehose-metric-stream.yaml
+++ b/logging-lambda-firehose-metric-stream.yaml
@@ -105,8 +105,8 @@ Parameters:
     ConstraintDescription: must only contain numbers
   NewRelicRegion:
     Type: String
-    Description: Datacenter where the data will be sent (US/EU), DO NOT TOUCH
-    AllowedValues: [US, EU]
+    Description: Datacenter where the data will be sent (US/EU/JP), DO NOT TOUCH
+    AllowedValues: [US, EU, JP]
     Default: US
   IntegrationName:
     Type: String

--- a/logging-lambda-firehose-template.yaml
+++ b/logging-lambda-firehose-template.yaml
@@ -52,6 +52,7 @@ Parameters:
     AllowedValues:
       - "US"
       - "EU"
+      - "JP"
   NewRelicAccountId: 
     Type: String
     Description: Id of the account in New relic

--- a/logging-lambda-metric-polling.yaml
+++ b/logging-lambda-metric-polling.yaml
@@ -74,8 +74,8 @@ Parameters:
     ConstraintDescription: must only contain numbers
   NewRelicRegion:
     Type: String
-    Description: Datacenter where the data will be sent (US/EU), DO NOT TOUCH
-    AllowedValues: [US, EU]
+    Description: Datacenter where the data will be sent (US/EU/JP), DO NOT TOUCH
+    AllowedValues: [US, EU, JP]
     Default: US
   IntegrationName:
     Type: String

--- a/logging-lambda-metric-stream.yaml
+++ b/logging-lambda-metric-stream.yaml
@@ -96,8 +96,8 @@ Parameters:
     ConstraintDescription: must only contain numbers
   NewRelicRegion:
     Type: String
-    Description: Datacenter where the data will be sent (US/EU), DO NOT TOUCH
-    AllowedValues: [US, EU]
+    Description: Datacenter where the data will be sent (US/EU/JP), DO NOT TOUCH
+    AllowedValues: [US, EU, JP]
     Default: US
   IntegrationName:
     Type: String

--- a/src/go.mod
+++ b/src/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.96.1
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.2
 	github.com/dsnet/compress v0.0.1
-	github.com/newrelic/newrelic-client-go/v2 v2.79.0
+	github.com/newrelic/newrelic-client-go/v2 v2.83.3
 	github.com/sirupsen/logrus v1.9.4
 	github.com/stretchr/testify v1.11.1
 )

--- a/src/go.sum
+++ b/src/go.sum
@@ -65,8 +65,8 @@ github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxec
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-github.com/newrelic/newrelic-client-go/v2 v2.79.0 h1:SNkjPjN8qpqrD/AmwHlHCTmN1oc4d5gMkXmbLOwOIro=
-github.com/newrelic/newrelic-client-go/v2 v2.79.0/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
+github.com/newrelic/newrelic-client-go/v2 v2.83.3 h1:K7ZICbj40uBSjwf8L2XpqBlYV9oqb95jV9HxWWC6Wfs=
+github.com/newrelic/newrelic-client-go/v2 v2.83.3/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
**Summary**

Adds JP (Japan) as a supported New Relic region across all CloudFormation templates, enabling customers to route logs and metrics to the New Relic Japan datacenter. Also bumps the newrelic-client-go SDK to the latest version v2.83.3. JP Region support is added back in [v2.83.0](https://github.com/newrelic/newrelic-client-go/releases/tag/v2.83.0).

**Testing**

 make test -  unit tests pass
 sam validate — all templates are valid
 

**Notes**

Default region remains US — no breaking change for existing deployments.
No application code changes required; the NR client SDK handles JP region-to-endpoint resolution natively